### PR TITLE
Updated the script to pull the most recent vintage EIA generator data, as of 2018.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,8 +3,9 @@
 # git history.
 
 # Individuals
-Josiah Johnston
-Benjamin Maluenda <bmaluenda@inodu.com>
+Josiah Johnston (original 2017 code)
+Benjamin Maluenda <bmaluenda@inodu.com> (original 2017 code)
+Julia Szinai (edits in 2020)
 
 # Organizations
 University of California Berkeley

--- a/database_interface.py
+++ b/database_interface.py
@@ -1,5 +1,6 @@
 # Copyright 2017. All rights reserved. See AUTHORS.txt
 # Licensed under the Apache License, Version 2.0 which is in LICENSE.txt
+# Modified 2020 by Julia Szinai
 """
 Defines several functions to finish processing EIA data and upload to the
 Switch-WECC database. Some functions may be used for other purposes.
@@ -11,28 +12,54 @@ import pandas as pd
 import numpy as np
 import getpass
 
+import matplotlib.pyplot as plt
+plt.switch_backend('agg')
+
 from IPython import embed
-from ggplot import *
+
 
 from utils import connect_to_db_and_run_query, append_historic_output_to_csv, connect_to_db_and_push_df
 
 coal_codes = ['ANT','BIT','LIG','SGC','SUB','WC','RC']
+# explanation of coal status codes:
+# ANT = Anthracite Coal, BIT = Bituminous Coal, LIG = Lignite Coal, SGC =
+# Coal-Derived Synthesis Gas, SUB = Subbituminous Coal, WC = Waste/Other Coal, RC =Recirculating cooling
 outputs_directory = 'processed_data'
 # Disable false positive warnings from pandas
 pd.options.mode.chained_assignment = None
 
+#generation_plant_scenario_id and generation_plant_existing_and_planned_scenario_id including individual generation plants is 19 and aggregated version of the same scenario is 20
+new_disaggregated_gen_scenario_id = 19.0
+new_aggregated_gen_scenario_id = 20.0
+
+#new hydro_simple_id (old hydro simple scenario id = 2 or 3)
+new_disaggregated_hydro_simple_scenario_id = 19.0
+new_aggregated_hydro_simple_scenario_id = 20.0
+
+#new generation_plant_cost_id (old generation_plant_cost_id = 2 or 3)
+new_disggregated_generation_plant_cost_id = 19.0
+new_aggregated_generation_plant_cost_id = 20.0
+
+#if testing code, run the script on backup tables first, which are defined with a PREFIX in the table name, otherwise is run on the main tables
+TESTING_ON_BACKUP_TABLES = False
+
+if TESTING_ON_BACKUP_TABLES:
+    PREFIX = 'jsz_backup_'
+else:
+    PREFIX = ''
 
 def pull_generation_projects_data(gen_scenario_id):
     """
     Returns generation plant data for a specific existing and planned scenario id.
     For now, only used to compare the old AMPL dataset with new heat rates.
+
     """
 
     print "Reading in existing and planned generation project data from database..."
     query = "SELECT * \
-            FROM generation_plant JOIN generation_plant_existing_and_planned \
+            FROM {PREFIX}generation_plant JOIN {PREFIX}generation_plant_existing_and_planned \
             USING (generation_plant_id) \
-            WHERE generation_plant_existing_and_planned_scenario_id = {}".format(gen_scenario_id)
+            WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}".format(PREFIX=PREFIX, gen_scenario_id=gen_scenario_id)
     db_gens = connect_to_db_and_run_query(query=query, database='switch_wecc')
     print "======="
     print "Read in {} projects from the database for id {}, with {:.0f} GW of capacity".format(
@@ -41,11 +68,67 @@ def pull_generation_projects_data(gen_scenario_id):
     print "Weighted average of heat rate: {:.3f} MMBTU/MWh".format(
         thermal_db_gens['capacity'].dot(thermal_db_gens['full_load_heat_rate'])/thermal_db_gens['capacity'].sum())
     print "======="
-    
+
     return db_gens
 
+def compare_generation_projects_scenario_data_by_energy_source(old_gen_scenario_id, new_gen_scenario_id):
+    """
+    Returns generation plant data for a prior existing and planned scenario id and compares with generation plant data for new added scenario,
+    grouping by gen_tech and energy source
 
-def filter_plants_by_region_id(region_id, year, host='localhost', area=0.5):
+    Use this function to compare generation_plant_existing_and_planned_scenario_id=2 (2015 EIA data)
+    with new generation_plant_existing_and_planned_scenario_id from the 2018 EIA data update
+
+    """
+    energy_source_list = ["Bio_Gas", "Wind","Waste_Heat","Coal","Solar","Bio_Solid","DistillateFuelOil","Uranium" ,"Gas" ,"Water","ResidualFuelOil","Geothermal","Bio_Liquid"]
+    wecc_states = ['AZ','CA','CO','ID','MT','NV','NM','OR','TX','UT','WA','WY']
+
+    print "Query of existing and planned generation project capacity by energy source from database from generation_plant_existing_and_planned_scenario_id {old_gen_scenario_id}...".format(old_gen_scenario_id=old_gen_scenario_id)
+
+    query = "SELECT SUM(capacity) as total_capacity_limit_mw, energy_source, gen_tech \
+            FROM {PREFIX}generation_plant \
+            JOIN {PREFIX}generation_plant_existing_and_planned \
+            USING (generation_plant_id) \
+            WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id} \
+            GROUP BY energy_source, gen_tech \
+            ORDER BY energy_source, gen_tech".format(PREFIX=PREFIX, gen_scenario_id = old_gen_scenario_id)
+    db_compare_gens_old_scenario = connect_to_db_and_run_query(query=query, database='switch_wecc')
+
+    print "Output into CSV the query result of total nameplate capacity by state and energy source for generation_plant_existing_and_planned_scenario_id {old_gen_scenario_id}...".format(old_gen_scenario_id=old_gen_scenario_id)
+
+    fpath = os.path.join('Nameplate capacity by energy source for gen plant scenario {old_gen_scenario_id}.tab').format(old_gen_scenario_id=old_gen_scenario_id)
+    with open(fpath, 'w') as outfile:
+        db_compare_gens_old_scenario.to_csv(outfile, sep='\t', header=True, index=False)
+
+    print "Query of existing and planned generation project capacity by energy source from database from generation_plant_existing_and_planned_scenario_id {new_gen_scenario_id}...".format(new_gen_scenario_id=old_gen_scenario_id)
+
+    query = "SELECT SUM(capacity) as total_capacity_limit_mw, energy_source, gen_tech \
+            FROM {PREFIX}generation_plant \
+            JOIN {PREFIX}generation_plant_existing_and_planned \
+            USING (generation_plant_id) \
+            WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id} \
+            GROUP BY energy_source, gen_tech \
+            ORDER BY energy_source, gen_tech".format(PREFIX=PREFIX, gen_scenario_id = new_gen_scenario_id)
+    db_compare_gens_new_scenario = connect_to_db_and_run_query(query=query, database='switch_wecc')
+
+    print "Output into CSV the query result of total nameplate capacity by state and energy source for generation_plant_existing_and_planned_scenario_id {new_gen_scenario_id}...".format(new_gen_scenario_id=new_gen_scenario_id)
+
+    fpath = os.path.join('Nameplate capacity by energy source for gen plant scenario {new_gen_scenario_id}.tab').format(new_gen_scenario_id=new_gen_scenario_id)
+    with open(fpath, 'w') as outfile:
+        db_compare_gens_new_scenario.to_csv(outfile, sep='\t', header=True, index=False)
+
+    compare_old_new_scenarios = pd.merge(db_compare_gens_new_scenario, db_compare_gens_old_scenario, how='left', on=['energy_source', 'gen_tech'], suffixes=('_new','_old'))
+
+    compare_old_new_scenarios['scenario_diff_mw'] = compare_old_new_scenarios['total_capacity_limit_mw_new'] - compare_old_new_scenarios['total_capacity_limit_mw_old']
+
+    fpath = os.path.join('Compare capacity by energy source for new and old gen plant scenarios.tab')
+    with open(fpath, 'w') as outfile:
+        compare_old_new_scenarios.to_csv(outfile, sep='\t', header=True, index=False)
+
+
+    return db_compare_gens_old_scenario, db_compare_gens_new_scenario
+
+def filter_plants_by_region_id(region_id, year, host='switch-db2.erg.berkeley.edu', area=0.5):
     """
     Filters generation plant data by NERC Region, according to the provided id.
     Generation plants w/o Region get assigned to the NERC Region with which more
@@ -111,22 +194,25 @@ def filter_plants_by_region_id(region_id, year, host='localhost', area=0.5):
         'Wyoming':'WY'
     }
 
-    print "Getting region name from database..."
+    #getting abbreviated name (regionabr) of NERC region from db (from switch_gis.public schema)
+    print "Getting NERC region name from database..."
     query = "SELECT regionabr FROM ventyx_nerc_reg_region WHERE gid={}".format(
         region_id)
     region_name = connect_to_db_and_run_query(query=query,
         database='switch_gis', host=host)['regionabr'][0]
+
+    #read in existing file with list of counties in each state in WECC or if file doesn't exist,
+    # assign county to state and WECC region if input % of area falls into region
     counties_path = os.path.join('other_data', '{}_counties.tab'.format(region_name))
-    
     if not os.path.exists(counties_path):
         # assign county if (area)% or more of its area falls in the region
         query = "SELECT name, state\
                  FROM ventyx_nerc_reg_region regions CROSS JOIN us_counties cts\
                  JOIN (SELECT DISTINCT state, state_fips FROM us_states) sts \
                  ON (sts.state_fips=cts.statefp) \
-                 WHERE regions.gid={} AND\
+                 WHERE regions.gid={region_id} AND\
                  ST_Area(ST_Intersection(cts.the_geom, regions.the_geom))/\
-                 ST_Area(cts.the_geom)>={}".format(region_id, area)
+                 ST_Area(cts.the_geom)>={area}".format(PREFIX=PREFIX, region_id=region_id, area=area)
         print "\nGetting counties and states for the region from database..."
         region_counties = pd.DataFrame(connect_to_db_and_run_query(query=query,
             database='switch_gis', host=host)).rename(columns={'name':'County','state':'State'})
@@ -136,6 +222,7 @@ def filter_plants_by_region_id(region_id, year, host='localhost', area=0.5):
         print "Reading counties from .tab file..."
         region_counties = pd.read_csv(counties_path, sep='\t', index_col=None)
 
+    #reading in the processed generator project data from scrape.py from EIA 860 forms for each year
     generators = pd.read_csv(
         os.path.join('processed_data','generation_projects_{}.tab'.format(year)), sep='\t')
     generators.loc[:,'County'] = generators['County'].map(lambda c: str(c).title())
@@ -144,6 +231,7 @@ def filter_plants_by_region_id(region_id, year, host='localhost', area=0.5):
     print "--{} are existing".format(len(generators[generators['Operational Status']=='Operable']))
     print "--{} are proposed".format(len(generators[generators['Operational Status']=='Proposed']))
 
+    #if generators don't have a NERC region already from the EIA data, assign region based on join on county and state
     generators_with_assigned_region = generators.loc[generators['Nerc Region'] == region_name]
     generators = generators[generators['Nerc Region'].isnull()]
     generators_without_assigned_region = pd.merge(generators, region_counties, how='inner', on=['County','State'])
@@ -177,10 +265,6 @@ def compare_eia_heat_rates_to_ampl_projs(year):
     rates of previously stored Switch AMPL data (generation scenario id 1) in
     the database.
 
-    ToDo: Only EIA860 data is merged with existing AMPL data, so no 'Best Heat
-    Rate' column is present. Need to also merge with EIA923 processed data
-    (historic_heat_rates_WIDE.tab file).
-    
     Returns the comparison DataFrame and prints it to a tab file.
     """
 
@@ -201,7 +285,7 @@ def compare_eia_heat_rates_to_ampl_projs(year):
         'Bio_Gas_Steam_Turbine':'ST'
         },
         inplace=True)
-    eia_gen_projects = filter_plants_by_region_id(13, year)
+    eia_gen_projects = filter_plants_by_region_id(13, year) #region 13 is WECC
 
     df = pd.merge(db_gen_projects, eia_gen_projects,
         on=['Plant Name','Prime Mover'], how='left').loc[:,[
@@ -210,16 +294,35 @@ def compare_eia_heat_rates_to_ampl_projs(year):
     df = df[df['full_load_heat_rate']>0]
 
     print "\nPrinting intersection of DB and EIA generation projects that have a specified heat rate to heat_rate_comparison.tab"
-    
+
     fpath = os.path.join('processed_data','heat_rate_comparison.tab')
     with open(fpath, 'w') as outfile:
         df.to_csv(outfile, sep='\t', header=True, index=False)
+
+    # Added a merge with 'best heat rate column'
+    eia_best_historic_heat_rate = pd.read_csv(
+        os.path.join('processed_data','historic_heat_rates_WIDE.tab', sep='\t'))
+    eia_best_historic_heat_rate = eia_best_historic_heat_rate[eia_best_historic_heat_rate['Year'] == year]
+
+    df2 = pd.merge(db_gen_projects, eia_best_historic_heat_rate,
+        on=['Plant Name','Prime Mover'], how='left').loc[:,[
+        'Plant Name','gen_tech','energy_source','full_load_heat_rate',
+        'Best Heat Rate','Prime Mover','Energy Source','Energy Source 2','Year']]
+    df2 = df2[df2['full_load_heat_rate']>0]
+
+    print "\nPrinting intersection of DB and EIA generation projects that have a specified heat rate to heat_rate_comparison.tab"
+
+    fpath = os.path.join('processed_data','heat_rate_comparison_wide_test.tab')
+    with open(fpath, 'w') as outfile:
+        df2.to_csv(outfile, sep='\t', header=True, index=False)
 
     return df
 
 
 def assign_heat_rates_to_projects(generators, year):
     """
+    Creates uniform fuel list based on https://www.seia.org/sites/default/files/EIA-860.pdf
+
     Assigns calculated heat rates based on EIA923 data to plants parsed from
     EIA860 data. Receives a DataFrame with all generators and the year.
 
@@ -228,14 +331,19 @@ def assign_heat_rates_to_projects(generators, year):
     plants with heat rate better (lower) than 6.711 MMBTU/MWh are ignored and get
     assigned an average heat rate, since we assume a report error has taken place.
 
+    Modified to also ignore heat rates that are too high (too bad to be realistic)
+    because they are 1 order of magnitude too high (greater than 100 MMBTU/MWh)
+
+    Average HR by energy source in recent years here: https://www.eia.gov/electricity/annual/html/epa_08_01.html
+
     The top and bottom .5% of heat rates get replaced by the heat rate at the
-    top and bottom .5 percentile, respectively. This replaces unrealistic values
+    top and bottom .5 percentile, respectively. This replaces unrealistic and missing values
     that must have been caused by reporting errors.
 
     Heat rate averages used to replace unrealistic values and to be assigned to
     projects without heat rate are calculated as the average heat rate of plants
     with the same technology, energy source and vintage. A 4-year window is used
-    to identify plants with similar vintage. If less than 4 plants fall into this
+    to identify plants with similar vintage. If fewer than 4 plants fall into this
     window, it is enlarged successively. If no other project with the same
     technology-energy source combination exists, then the technology's average
     heat rate is used. The last two assignments (per technology-energy source-window
@@ -245,43 +353,45 @@ def assign_heat_rates_to_projects(generators, year):
     Heat rate distributions per technology and energy source are plotted and
     printed to a PDF file in order to visually inspect them.
 
-    Returns the original DataFrame with a Best Heat Rate column.    
+    Returns the original DataFrame with a Best Heat Rate column.
 
     """
 
     fuels = {
-        'LFG':'Bio_Gas',
-        'OBG':'Bio_Gas',
-        'AB':'Bio_Solid',
-        'BLQ':'Bio_Liquid',
-        'NG':'Gas',
-        'OG':'Gas',
-        'PG':'Gas',
-        'DFO':'DistillateFuelOil',
-        'JF':'ResidualFuelOil',
+        'LFG':'Bio_Gas', #landfill gas
+        'OBG':'Bio_Gas', #other biomass gas
+        'AB':'Bio_Solid', #agricultural by-product
+        'BLQ':'Bio_Liquid', #black liquor
+        'NG':'Gas', #natural gas
+        'OG':'Gas', #other gas
+        'PG':'Gas', #propane
+        'DFO':'DistillateFuelOil', #distillate fuel oil
+        'JF':'ResidualFuelOil', #jet fuel
         'COAL':'Coal',
-        'GEO':'Geothermal',
-        'NUC':'Uranium',
-        'PC':'Coal',
-        'SUN':'Solar',
-        'WDL':'Bio_Liquid',
-        'WDS':'Bio_Solid',
-        'MSW':'Bio_Solid',
-        'PUR':'Purchased_Steam',
-        'WH':'Waste_Heat',
-        'OTH':'Other',
-        'WAT':'Water',
-        'MWH':'Electricity',
-        'WND':'Wind'
+        'GEO':'Geothermal', #geothermal
+        'NUC':'Uranium', #nuclear
+        'PC':'Coal', #Petroleum Coke
+        'SUN':'Solar', #solar
+        'WDL':'Bio_Liquid', #wood waste liquids
+        'WDS':'Bio_Solid', #wood waste solids
+        'MSW':'Bio_Solid', #municipal solid waste
+        'PUR':'Purchased_Steam', #purchased steam
+        'WH':'Waste_Heat', #Waste heat not directly attributed to a fuel source
+        'OTH':'Other', #other
+        'WAT':'Water', #water (hydro)
+        'MWH':'Electricity', #Electricity used for energy storage
+        'WND':'Wind' #wind
     }
     generators = generators.replace({'Energy Source':fuels})
 
     existing_gens = generators[generators['Operational Status']=='Operable']
     print "-------------------------------------"
-    print "There are {} existing thermal projects that sum up to {:.1f} GW.".format(
+    print "There are {} existing operable thermal projects that sum up to {:.1f} GW.".format(
         len(existing_gens[existing_gens['Prime Mover'].isin(['CC','GT','IC','ST'])]),
         existing_gens[existing_gens['Prime Mover'].isin(['CC','GT','IC','ST'])][
             'Nameplate Capacity (MW)'].sum()/1000)
+
+    #reading in previously processed historic heat rate
     heat_rate_data = pd.read_csv(
         os.path.join('processed_data','historic_heat_rates_WIDE.tab'), sep='\t').rename(
         columns={'Plant Code':'EIA Plant Code'})
@@ -291,7 +401,6 @@ def assign_heat_rates_to_projects(generators, year):
         existing_gens, heat_rate_data[['EIA Plant Code','Prime Mover','Energy Source','Best Heat Rate']],
         how='left', suffixes=('',''),
         on=['EIA Plant Code','Prime Mover','Energy Source']).drop_duplicates()
-
     thermal_gens = thermal_gens[thermal_gens['Prime Mover'].isin(['CC','GT','IC','ST'])]
 
     # Replace null and unrealistic heat rates by average values per technology,
@@ -300,7 +409,8 @@ def assign_heat_rates_to_projects(generators, year):
     unrealistic_heat_rates = (((thermal_gens['Energy Source'] == 'Coal') &
             (thermal_gens['Best Heat Rate'] < 8.607)) |
         ((thermal_gens['Energy Source'] != 'Coal') &
-            (thermal_gens['Best Heat Rate'] < 6.711)))
+            (thermal_gens['Best Heat Rate'] < 6.711)) |
+            (thermal_gens['Best Heat Rate'] > 100)) # Additional criteria for upper outliers
     print "{} generators don't have heat rate data specified ({:.1f} GW of capacity)".format(
         len(thermal_gens[null_heat_rates]), thermal_gens[null_heat_rates]['Nameplate Capacity (MW)'].sum()/1000.0)
     print "{} generators have better heat rate than the best historical records ({} GW of capacity)".format(
@@ -318,10 +428,10 @@ def assign_heat_rates_to_projects(generators, year):
     #         print "\t{} use {}".format(
     #             len(thermal_gens_wo_hr[(thermal_gens_wo_hr['Energy Source']==fuel) &
     #                 (thermal_gens_wo_hr['Prime Mover']==prime_mover)]),prime_mover)
-    
+
     print "-------------------------------------"
     print "Assigning max/min heat rates per technology and fuel to top .5% / bottom .5%, respectively:"
-    n_outliers = int(len(thermal_gens_w_hr)*0.008)
+    n_outliers = int(len(thermal_gens_w_hr)*0.005)
     thermal_gens_w_hr = thermal_gens_w_hr.sort_values('Best Heat Rate')
     min_hr = thermal_gens_w_hr.loc[thermal_gens_w_hr.index[n_outliers],'Best Heat Rate']
     max_hr = thermal_gens_w_hr.loc[thermal_gens_w_hr.index[-1-n_outliers],'Best Heat Rate']
@@ -334,22 +444,22 @@ def assign_heat_rates_to_projects(generators, year):
         thermal_gens_w_hr.loc[thermal_gens_w_hr.index[i],'Best Heat Rate'] = min_hr
         thermal_gens_w_hr.loc[thermal_gens_w_hr.index[-1-i],'Best Heat Rate'] = max_hr
 
-
+    #window = 2 means the average HR is assigned +/- 2 years, or a 4 year wide window
     def calculate_avg_heat_rate(thermal_gens_df, prime_mover, energy_source, vintage, window=2):
         similar_generators = thermal_gens_df[
             (thermal_gens_df['Prime Mover']==prime_mover) &
             (thermal_gens_df['Energy Source']==energy_source) &
             (thermal_gens_df['Operating Year']>=vintage-window) &
             (thermal_gens_df['Operating Year']<=vintage+window)]
-        while len(similar_generators) < 4:
+        while len(similar_generators) < 4: # If fewer than 4 plants fall into this window, it is enlarged successively.
             window += 2
             similar_generators = thermal_gens_df[
                 (thermal_gens_df['Prime Mover']==prime_mover) &
                 (thermal_gens_df['Energy Source']==energy_source) &
                 (thermal_gens_df['Operating Year']>=vintage-window) &
                 (thermal_gens_df['Operating Year']<=vintage+window)]
-            # Gens span from 1925 to 2015, so a window of 90 years is the maximum
-            if window >= 90:
+            # thermal generator operating years span from 1925 to 2018, so a window of 103 years is the maximum
+            if window >= 103:
                 break
         if len(similar_generators) > 0:
             return similar_generators['Best Heat Rate'].mean()
@@ -374,15 +484,20 @@ def assign_heat_rates_to_projects(generators, year):
 
     # Plot histograms for resulting heat rates per technology and fuel
     thermal_gens["Technology"] = thermal_gens["Energy Source"].map(str) + ' ' + thermal_gens["Prime Mover"]
-    p = ggplot(aes(x='Best Heat Rate',fill='Technology'), data=thermal_gens) + geom_histogram(binwidth=0.5) + facet_wrap("Technology")  + ylim(0,30)
-    p.save(os.path.join(outputs_directory,'heat_rate_distributions.pdf'))
+    # Commented out because of a pandas update that caused an error with ggplot2. The associated ggplot plotting code (for diagnostics) is also commented out in the script below
+    #from ggplot import *
+    #import rpy2
+    #from pandas import Timestamp
+    #p = ggplot(aes(x='Best Heat Rate',fill='Technology'), data=thermal_gens) + geom_histogram(binwidth=0.5) + facet_wrap("Technology")  + ylim(0,30)
+    #p.save(os.path.join(outputs_directory,'heat_rate_distributions.pdf'))
 
+    #assigning average heat rate of technology for proposed generation based on calculated average HR of available HR from EIA data (2004-2018)
     proposed_gens = generators[generators['Operational Status']=='Proposed']
     thermal_proposed_gens = proposed_gens[proposed_gens['Prime Mover'].isin(['CC','GT','IC','ST'])]
     other_proposed_gens = proposed_gens[~proposed_gens['Prime Mover'].isin(['CC','GT','IC','ST'])]
     print "There are {} proposed thermal projects that sum up to {:.2f} GW.".format(
         len(thermal_proposed_gens), thermal_proposed_gens['Nameplate Capacity (MW)'].sum()/1000)
-    print "Assigning average heat rate of technology and fuel of most recent years..."
+    print "Assigning average heat rate of technology and fuel of most recent years from EIA (2004-2018)..."
     for idx in thermal_proposed_gens.index:
         pm = thermal_proposed_gens.loc[idx,'Prime Mover']
         es = thermal_proposed_gens.loc[idx,'Energy Source']
@@ -400,6 +515,10 @@ def finish_project_processing(year):
     """
     Receives a year, and processes the scraped EIA data for that year by using
     previously defined functions.
+
+    The year that should be input is the most recent year of EIA data. At the time
+    of updating this script (Aug 2020), 2018 was the the most recent available vintage
+    of "final" (not preliminary) EIA data.
 
     First, plants are read in from the generation_projects_YEAR.tab file, which
     come from the EIA860 form, and filtered by region. For now, region 13 (WECC)
@@ -420,12 +539,15 @@ def finish_project_processing(year):
     so it could be used for any other purpose.
 
     """
-
+    #assign generators to NERC regions and filter list just to WECC generators in given year
     generators = filter_plants_by_region_id(13, year)
+    #assign average heat rates from similar vintage and technology to thermal
+    # generators with missing or unrealistic heat rates
     generators = assign_heat_rates_to_projects(generators, year)
     existing_gens = generators[generators['Operational Status']=='Operable']
     proposed_gens = generators[generators['Operational Status']=='Proposed']
 
+    #output to CSV the list of existing generation projects that have been processed for the given year
     fname = 'existing_generation_projects_{}.tab'.format(year)
     with open(os.path.join(outputs_directory, fname),'w') as f:
         existing_gens.to_csv(f, sep='\t', encoding='utf-8', index=False)
@@ -447,6 +569,7 @@ def finish_project_processing(year):
         else:
             print "There is more than one option for uprating plant id {}, prime mover {} and energy source {}".format(int(pc), pm, es)
 
+    #output to CSV the list of proposed generation projects that have been processed for the given year
     fname = 'new_generation_projects_{}.tab'.format(year)
     with open(os.path.join(outputs_directory, fname),'w') as f:
         new_gens.to_csv(f, sep='\t', encoding='utf-8', index=False)
@@ -463,8 +586,19 @@ def upload_generation_projects(year):
 
     First, generation project data is read in from the processed tab files.
 
-    Projects using Electricity or Purchased Steam as their energy source are
+    Projects using Purchased Steam as their energy source are
     dropped from the generator set.
+
+    Projects using Electricity as their energy source were previously also
+    dropped from the generator set. But given the growing share of batteries in
+    the capacity mix (presumably to meet the CA storage mandate), Batteries are removed
+    from the "ignored" list and included in the list of existing and
+    proposed generation.
+
+    The list of retired plants in WECC that are still in the generator list is read in
+    from the processed tab files. This list is joined with the processed plant-level list above
+    and the retired nameplate capacity is subtracted. If the remaining capacity is 0, the
+    plant is dropped from the list before uploading to the database.
 
     Projects using Other as their energy source are assigned Gas as default.
 
@@ -480,19 +614,21 @@ def upload_generation_projects(year):
     Baseload flags are set for all plants that use Nuclear, Coal, or Geothermal
     as their energy source.
 
-    Variable flags are set for all plants that use Hydro, Photovoltaic, or Wind
-    Turbine technologies.
+    Variable flags are set for all plants that use Hydro, Photovoltaic, or
+    Wind Turbine technologies.
 
     Cogen flags are set for all plants that declared being Cogen.
 
     Columns are renamed to match the PSQL database column definitions.
 
     Resulting generation plant data is uploaded to the database with generation
-    plant scenario id 2. A subsequent aggregated set per technology, energy source,
-    and load zone is uploaded with id 3.
-    
+    plant scenario id 19 for 2018 vintage EIA data (previously was scenario 2 for
+    2015 vintage EIA data). A subsequent aggregated set per technology, energy source,
+    and load zone is uploaded with id 20 for 2018 vintage EIA data (previously
+    was scenario 3 for 2015 vintage EIA data).
+
     WARNING: The upload process will clean the database from all previous projects
-    with ids 2 and 3. This includes:
+    with the same scenario ids (previously 2 and 3, now 19 and 20). This includes:
         Hydro capacity factors
         Plant cost
         Plant build years
@@ -500,7 +636,7 @@ def upload_generation_projects(year):
         Plant level data
         But not variable capacity factor data (that was uploaded after finishing
             this part of the code, so its still in the todo list).
-    
+
     After uploading generation plant data, the geom column is populated with
     the geometric object representing the location of the project, for those
     projects with latitude and longitude defined.
@@ -516,12 +652,16 @@ def upload_generation_projects(year):
         only a couple of cases in the East Coast, which must have a reporting
         mistake).
 
-    Maximum age, outage rates, and variable O&M costs are assigned as
-    technology-default values.
+    Outage rates, and variable O&M costs are assigned as
+    technology-default values. For battery_storage gen_tech these technology-default
+    values are copied into the technology default table from that of proposed
+    battery storage in another scenario
 
-    The Diablo Canyon nuclear power plant is set a maximum age of 40 years.
+    For the generators that have planned retirements, the max age is
+    set to the planned retirement year - operating year. For all other generators,
+    a technology-default value is assigned for the max age.
 
-    Uploaded plants are assigned to generation plant scenario id 2.
+    Uploaded plants are assigned to generation plant scenario id 19 (was 2).
 
     The uploaded generation plant ids are recovered, so that build year data
     can be uploaded for existing and new projects.
@@ -530,7 +670,7 @@ def upload_generation_projects(year):
 
     Hydro capacity factors are uploaded for each hydro plant, according to
     nameplate capacity. Minimum flows are set to a default of 0.5 times the
-    average flow. The hydro scenario id is set to 2.
+    average flow. The hydro scenario id is set to 19 (was 2).
 
     The plant dataset is then aggregated by technology, energy source, and load
     zone, considering heat rate windows of 1 MMBTU/MWh (so that plants with
@@ -538,14 +678,21 @@ def upload_generation_projects(year):
     are averaged by weighting the capacity of each plant. Other properties,
     such as capacity limit, are simply summed.
 
-    The dataset is uploaded with id 3, and build years, hydro capacity factors,
-    and all other data is processed in the same way as for id 2.   
+    In the 2020 update, the dataset is uploaded with id 20 (was 3 in 2017),
+    and build years, hydro capacity factors, and all other data is processed
+    in the same way as for id 19 (was 2 in 2017).
+
+    The scenario "mapping" tables (generation_plant_scenario,
+    hydro_simple_scenario, generation_plant_cost_scenario, generation_plant_existing_and_planned_scenario)
+     are updated to include the new scenario ids and scenario description
 
     """
-
-    user = getpass.getpass('Enter username for the database:')
-    password = getpass.getpass('Enter database password for user {}:'.format(user))
-
+    try:
+        user = os.environ['SWITCH_USERNAME']
+        password = os.environ['SWITCH_PASSWORD']
+    except KeyError:
+        user = getpass.getpass('Enter username for the database:')
+        password = getpass.getpass('Enter database password for user {}:'.format(user))
     def read_output_csv(fname):
         try:
             return pd.read_csv(os.path.join(outputs_directory,fname), sep='\t', index_col=None)
@@ -570,9 +717,15 @@ def upload_generation_projects(year):
 
     generators = pd.concat([existing_gens, new_gens], axis=0)
 
-    ignore_energy_sources = ['Purchased_Steam','Electricity']
+    # Batteries were previously included on the list of ignored energy sources. But there are existing
+    # batteries on the system, and as of the 2018 vintage EIA data about 800MW of batteries that are proposed.
+    # So I have removed batteries from the list of ignored projects because it is a significant capacity amount
+    # (to meet CA storage mandate)
 
-    print ("Dropping projects that use Batteries or Purchased Steam, since these"
+    ignore_energy_sources = ['Purchased_Steam']
+    #ignore_energy_sources = ['Purchased_Steam','Electricity']
+
+    print ("Dropping projects that use Purchased Steam, since these"
     " are not modeled in Switch, totalizing {:.2f} GW of capacity").format(
         generators[generators['Energy Source'].isin(
             ignore_energy_sources)]['Nameplate Capacity (MW)'].sum()/1000.0)
@@ -583,9 +736,71 @@ def upload_generation_projects(year):
             ignore_energy_sources)].index, inplace=True)
     generators.replace({'Energy Source':{'Other':'Gas'}}, inplace=True)
 
+    # Reading in the previously processed list of generators in WECC states that are retired or have
+    # planned retirements, but are still in the list of existing or planned generation projects in WECC states.
+    # This list of retired generators has had its capacity aggregated to the plant level by energy source, prime mover, and
+    # operating year.
+
+    retired_gens = read_output_csv('retired_WECC_aggregated_generation_projects_{}.tab'.format(year))
+
+    retired_gens = retired_gens.rename(columns = {'Nameplate Capacity (MW)':'retired_capacity_mw'})
+
+    print "Joining the aggregated capacity by plant with retired capacity by plant..."
+
+    #join the aggregated (by plant) retired generator projects with the aggregated existing generator projects (by plant)
+    index_cols = ['EIA Plant Code','Prime Mover', 'State','County', 'Operating Year']
+
+    generators_and_retired = pd.merge(generators, retired_gens, on=index_cols, how='left')
+
+    #subtract out the retired nameplate capacity from the aggregated existing generator capacity
+    generators_and_retired['net_operating_capacity_limit_mw'] = generators_and_retired['Nameplate Capacity (MW)']- generators_and_retired['retired_capacity_mw']
+
+    #drop generators entirely if the remaining nameplate capacity = 0 after retirements are subtracted out
+    generators_no_retired = generators_and_retired[generators_and_retired['net_operating_capacity_limit_mw'] != 0]
+
+    #for several instances where only a portion of the nameplate capacity is retired, the Nameplate Capcity
+    # column is replaced with this difference value of remaining capacity
+    generators_no_retired['Nameplate Capacity (MW)'] = np.where(generators_no_retired['net_operating_capacity_limit_mw'] > 0, generators_no_retired['net_operating_capacity_limit_mw'], generators_no_retired['Nameplate Capacity (MW)'])
+
+    print ("Dropping {} projects from generator list that have since been retired, totaling {:.2f} GW of capacity").format(
+        len(generators_and_retired) - len(generators_no_retired),sum(generators_and_retired['retired_capacity_mw'])/1000.0)
+
+    #calculating the "max_age" parameter for generators that are still operating but have a planned retirement date as
+    #the Planned Retirement Year - Operating Year. If no retirement year not >0, make max age = 0. This will be replaced by techology default values in the database
+
+    #generators_no_retired = generators_no_retired.astype({'Planned Retirement Year': 'int64', 'Operating Year':'int64'})
+    generators_no_retired['Planned Retirement Year'][generators_no_retired['Planned Retirement Year'] == ' '] = 0
+    generators_no_retired = generators_no_retired.astype({'Planned Retirement Year': 'float'})
+
+    generators_no_retired['max_age'] = np.where(generators_no_retired['Planned Retirement Year'] > 0, generators_no_retired['Planned Retirement Year'] - generators_no_retired['Operating Year'], 0)
+
+    generators_no_retired = generators_no_retired.astype({'max_age': 'int64'})
+
+    #output to CSV the list of generators without retirements
+    fname = 'WECC_non_retired_generation_projects_{}.tab'.format(year)
+    with open(os.path.join(outputs_directory, fname),'w') as f:
+        generators_no_retired.to_csv(f, sep='\t', encoding='utf-8', index=False)
+        print "Saved data to {} file.\n".format(fname)
+
+    #output to CSV the list of generators with retirements still flagged
+    fname= 'WECC_generators_and_retired_projects_{}.tab'.format(year)
+    with open(os.path.join(outputs_directory, fname),'w') as f:
+        generators_and_retired.to_csv(f, sep='\t', encoding='utf-8', index=False)
+        print "Saved data to {} file.\n".format(fname)
+
+    #Dropping the unnecssary columns and renaming the dataframe back to "generators" now that the capacity of retired generators has been removed
+    generators_no_retired = generators_no_retired.rename(columns={'Plant Name_x':'Plant Name'})
+    generators_no_retired = generators_no_retired.drop(['Plant Name_y','retired_capacity_mw','Regulatory Status','net_operating_capacity_limit_mw'], axis=1)
+
+    generators = generators_no_retired
 
     def weighted_avg(group, avg_name, weight_name):
         """
+        Plant-level heat rates are calculated by doing a capacity-weighted average
+        over the individual heat rates of each unit in the plant that have the same
+        technology and use the same energy source. This allows obtaining a single
+        heat rate for plants with units that have different vintages.
+
         http://stackoverflow.com/questions/10951341/pandas-dataframe-aggregate-function-using-multiple-columns
         """
         d = group[avg_name]
@@ -595,11 +810,12 @@ def upload_generation_projects(year):
         except ZeroDivisionError:
             return d.mean()
 
+
     index_cols = ['EIA Plant Code','Prime Mover','Energy Source']
     print "Calculating capacity-weighted average heat rates per plant, technology and energy source..."
     generators = pd.merge(generators,
         pd.DataFrame(generators.groupby(index_cols).apply(weighted_avg, 'Best Heat Rate',
-            'Nameplate Capacity (MW)')).reset_index().replace(0, float('nan')),
+        'Nameplate Capacity (MW)')).reset_index().replace(0, float('nan')),
         how='right',
         on=index_cols).drop('Best Heat Rate', axis=1)
 
@@ -607,9 +823,9 @@ def upload_generation_projects(year):
     gb = generators.groupby(index_cols)
     agg_generators = gb.agg({col:sum if col == 'Nameplate Capacity (MW)' else 'max'
                                     for col in generators.columns}).rename(columns=
-                                    {'Nameplate Capacity (MW)':'capacity_limit_mw'})
+                                    {'Nameplate Capacity (MW)':'capacity_limit_mw'}).reset_index(drop=True)
     generators = pd.merge(generators, agg_generators[index_cols+['capacity_limit_mw']],
-        on=index_cols, how='right')
+        on=index_cols, how='right').reset_index(drop=True)
 
     print "Assigning baseload, variable and cogen flags..."
     generators.loc[:,'is_baseload'] = np.where(generators['Energy Source'].isin(
@@ -628,12 +844,19 @@ def upload_generation_projects(year):
         'Energy Source':'energy_source',
         0:'full_load_heat_rate',
         'Operating Year':'build_year',
-        'Nameplate Capacity (MW)':'capacity'
+        'Nameplate Capacity (MW)':'capacity',
+        'max_age':'max_age'
         }
 
     generators.rename(columns=database_column_renaming_dict, inplace=True)
 
     generators.replace(' ',float('nan'), inplace=True)
+
+    #round full load heat rate column to 3 decimal places
+    generators['full_load_heat_rate'] = generators['full_load_heat_rate'].round(decimals=3)
+
+    #rename battery storage gen_tech to match database naming convention
+    generators['gen_tech'] = np.where(generators['gen_tech'] == 'BA', 'Battery_Storage', generators['gen_tech'])
 
     carry_on = getpass.getpass('WARNING: In order to push projects into the DB,'
         'all projects currently in the generation_plant table that are'
@@ -652,62 +875,87 @@ def upload_generation_projects(year):
 
     # Make sure the "switch" schema is on the search path
 
-    # Drop NOT NULL constraint for load_zone_id & max_age cols to avoid raising error
-    query = 'ALTER TABLE "generation_plant" ALTER "load_zone_id" DROP NOT NULL;'
+    # Drop NOT NULL constraint for load_zone_id
+    query = 'ALTER TABLE "{PREFIX}generation_plant" ALTER "load_zone_id" DROP NOT NULL;'.format(PREFIX=PREFIX)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
-    query = 'ALTER TABLE "generation_plant" ALTER "max_age" DROP NOT NULL;'
+    query = 'ALTER TABLE "{PREFIX}generation_plant" ALTER "max_age" DROP NOT NULL;'.format(PREFIX=PREFIX)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
 
-    # First, delete previously stored projects for the EIA scenario id
-    gen_scenario_id = 2.0
+    # First, define gen_scenario_id as new_disaggregated_gen_scenario_id and delete previously stored projects for the scenario id
+    gen_scenario_id = new_disaggregated_gen_scenario_id
+    # Also define hydro simple scenario and generation_plant_cost scenario and delete previously stored projects for these scenario ids
+    hydro_scenario_id = new_disaggregated_hydro_simple_scenario_id
+    generation_plant_cost_id = new_disggregated_generation_plant_cost_id
 
-    query = 'DELETE FROM hydro_historical_monthly_capacity_factors\
-        WHERE hydro_simple_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}hydro_historical_monthly_capacity_factors\
+        WHERE hydro_simple_scenario_id = {hydro_scenario_id}'.format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM generation_plant_scenario_member\
-        WHERE generation_plant_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}generation_plant_scenario_member\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM generation_plant_cost\
-        WHERE generation_plant_cost_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}generation_plant_cost\
+        WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}'.format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM generation_plant_existing_and_planned\
-        WHERE generation_plant_existing_and_planned_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}generation_plant_existing_and_planned\
+        WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    # These queries are for the scenario mapping tables to add descriptions of new scenarios
+    query = 'DELETE FROM {PREFIX}hydro_simple_scenario\
+        WHERE hydro_simple_scenario_id = {hydro_scenario_id}'.format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_cost_scenario\
+        WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}'.format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_existing_and_planned_scenario\
+        WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_scenario\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
     # It is necessary to temporarily disable triggers when deleting from
     # generation_plant table, because of multiple fkey constraints
     query = 'SET session_replication_role = replica;\
-            DELETE FROM generation_plant\
+            DELETE FROM {PREFIX}generation_plant\
             WHERE generation_plant_id NOT IN\
-            (SELECT generation_plant_id FROM generation_plant_scenario_member);\
-            SET session_replication_role = DEFAULT;'
+            (SELECT generation_plant_id FROM {PREFIX}generation_plant_scenario_member);\
+            SET session_replication_role = DEFAULT;'.format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    print "Deleted previously stored projects for the EIA dataset (id 2). Pushing data..."
+    print "Deleted previously stored projects for the EIA dataset (id {}). Pushing data...".format(gen_scenario_id)
 
     query = 'SELECT last_value FROM generation_plant_id_seq'
     first_gen_id = connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True).iloc[0,0] + 1
 
+    # Aded max_age to the list of uploaded columns for generators will planned
+    # retirements, if a generator has no planned retirement, default max_age will be assigned in a later step
     generators_to_db = generators[['name','gen_tech','capacity_limit_mw',
-        'full_load_heat_rate','is_variable','is_baseload','is_cogen',
+        'full_load_heat_rate','max_age','is_variable','is_baseload','is_cogen',
         'energy_source','eia_plant_code', 'Latitude','Longitude','County',
         'State']].drop_duplicates()
 
     connect_to_db_and_push_df(df=generators_to_db,
-        col_formats=("(DEFAULT,%s,%s,NULL,NULL,%s,NULL,NULL,NULL,%s,NULL,NULL,"
-            "NULL,%s,%s,%s,%s,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,%s,%s,%s,%s,%s,NULL)"),
-        table='generation_plant',
+        col_formats=("(DEFAULT,%s,%s,NULL,NULL,%s,NULL,NULL,NULL,%s,NULL,%s,NULL,%s,%s,%s,%s,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,%s,%s,%s,%s,%s,NULL,NULL,NULL)"),
+        table='{PREFIX}generation_plant'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully pushed generation plants!"
 
@@ -715,38 +963,42 @@ def upload_generation_projects(year):
     last_gen_id = connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True).iloc[0,0]
 
-    # Populate geometry column for GIS work
-    query = "UPDATE generation_plant\
+    # Populate geometry column for GIS work, using coordinate reference system 4326-WGS4 (common projection default)
+    query = "UPDATE {PREFIX}generation_plant\
         SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)\
         WHERE longitude IS NOT NULL AND latitude IS NOT NULL AND\
-        generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id)
+        generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
 
+    # assigning generators to load zones
+
+    # if generator lat-lon is available assign if within load zone boundary
     print "\nAssigning load zones..."
-    query = "UPDATE generation_plant SET load_zone_id = z.load_zone_id\
-        FROM load_zone z\
+    query = "UPDATE {PREFIX}generation_plant SET load_zone_id = z.load_zone_id\
+        FROM {PREFIX}load_zone z\
         WHERE ST_contains(boundary, geom) AND\
-        generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id)
+        generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
     n_plants_assigned_by_lat_long = connect_to_db_and_run_query("SELECT count(*)\
-        FROM generation_plant WHERE load_zone_id IS NOT NULL AND\
-        generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id),
+        FROM {PREFIX}generation_plant WHERE load_zone_id IS NOT NULL AND\
+        generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id),
         database='switch_wecc', user=user, password=password, quiet=True).iloc[0,0]
     print "--Assigned load zone according to lat & long to {} plants".format(
         n_plants_assigned_by_lat_long)
 
-    query = "UPDATE generation_plant g SET load_zone_id = z.load_zone_id\
-        FROM us_counties c\
-        JOIN load_zone z ON ST_contains(z.boundary, ST_centroid(c.the_geom))\
+    #if generator lat-lon is not available, assign load zone based on state and county of generator
+    query = "UPDATE {PREFIX}generation_plant g SET load_zone_id = z.load_zone_id\
+        FROM {PREFIX}us_counties c\
+        JOIN {PREFIX}load_zone z ON ST_contains(z.boundary, ST_centroid(c.the_geom))\
         WHERE g.load_zone_id IS NULL AND g.state = c.state_name AND g.county = c.name\
-        AND generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id)
+        AND generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
     n_plants_assigned_by_county_state = connect_to_db_and_run_query("SELECT count(*)\
-        FROM generation_plant WHERE load_zone_id IS NOT NULL AND\
-        generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id),
+        FROM {PREFIX}generation_plant WHERE load_zone_id IS NOT NULL AND\
+        generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id),
         database='switch_wecc', user=user, password=password, quiet=True
         ).iloc[0,0] - n_plants_assigned_by_lat_long
     print "--Assigned load zone according to county & state to {} plants".format(
@@ -755,91 +1007,195 @@ def upload_generation_projects(year):
     # Plants that are located outside of the WECC region boundary get assigned
     # to the nearest load zone, ONLY if they are located less than 100 miles
     # out of the boundary
-    query = "UPDATE generation_plant AS g1 SET load_zone_id = lz1.load_zone_id\
-        FROM load_zone lz1\
+    query = "UPDATE {PREFIX}generation_plant AS g1 SET load_zone_id = lz1.load_zone_id\
+        FROM {PREFIX}load_zone lz1\
         WHERE g1.load_zone_id is NULL AND g1.geom IS NOT NULL\
-        AND g1.generation_plant_id between {} AND {}\
+        AND g1.generation_plant_id between {first_gen_id} AND {last_gen_id}\
         AND ST_Distance(g1.geom::geography,lz1.boundary::geography)/1609 < 100\
         AND ST_Distance(g1.geom::geography,lz1.boundary::geography)/1609 = \
         (SELECT min(ST_Distance(g2.geom::geography,lz2.boundary::geography)/1609)\
-        FROM generation_plant g2\
-        CROSS JOIN load_zone lz2\
+        FROM {PREFIX}generation_plant g2\
+        CROSS JOIN {PREFIX}load_zone lz2\
         WHERE g2.load_zone_id is NULL AND g2.geom IS NOT NULL\
-        AND g2.generation_plant_id = g1.generation_plant_id)".format(first_gen_id, last_gen_id)
+        AND g2.generation_plant_id = g1.generation_plant_id)".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
     n_plants_assigned_to_nearest_lz = connect_to_db_and_run_query("SELECT count(*)\
-        FROM generation_plant WHERE load_zone_id IS NOT NULL AND\
-        generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id),
+        FROM {PREFIX}generation_plant WHERE load_zone_id IS NOT NULL AND\
+        generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id),
         database='switch_wecc', user=user, password=password, quiet=True
         ).iloc[0,0] - n_plants_assigned_by_lat_long - n_plants_assigned_by_county_state
     print "--Assigned load zone according to nearest load zone to {} plants".format(
         n_plants_assigned_to_nearest_lz)
 
     plants_wo_load_zone_count_and_cap = connect_to_db_and_run_query("SELECT count(*),\
-        sum(capacity_limit_mw) FROM generation_plant WHERE load_zone_id IS NULL\
-        AND generation_plant_id BETWEEN {} AND {}".format(first_gen_id, last_gen_id),
+        sum(capacity_limit_mw) FROM {PREFIX}generation_plant WHERE load_zone_id IS NULL\
+        AND generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id),
         database='switch_wecc', user=user, password=password, quiet=True)
     if plants_wo_load_zone_count_and_cap.iloc[0,0] > 0:
         print ("--WARNING: There are {:.0f} plants with a total of {:.2f} GW of capacity"
         " w/o an assigned load zone. These will be removed.").format(
         plants_wo_load_zone_count_and_cap.iloc[0,0],
         plants_wo_load_zone_count_and_cap.iloc[0,1]/1000.0)
-        connect_to_db_and_run_query("DELETE FROM generation_plant\
-            WHERE load_zone_id IS NULL AND generation_plant_id BETWEEN {}\
-            AND {}".format(first_gen_id, last_gen_id),
+        connect_to_db_and_run_query("DELETE FROM {PREFIX}generation_plant\
+            WHERE load_zone_id IS NULL AND generation_plant_id BETWEEN {first_gen_id}\
+            AND {last_gen_id}".format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id),
             database='switch_wecc', user=user, password=password, quiet=True)
 
     # Assign default technology values
-    print "\nAssigning default technology parameter values..."
-    for param in ['max_age','forced_outage_rate','scheduled_outage_rate', 'variable_o_m']:
-        query = "UPDATE generation_plant g SET {} = t.{}\
-                FROM generation_plant_technologies t\
+
+    # Note: Outside of this script I had previously copied the default technology parameters of wind for battery storage (max age = 20, variable om, forced outage rate, scheduled outage rate all
+    # = 0,  and existing fixed om cost, and existing overnight cost are null. Then updated to have max age of 10, forced out = 0.02, scheduled out = 0.0055)
+    #postgres queries:
+        # insert into switch.generation_plant_technologies (gen_tech, energy_source, max_age, variable_o_m, forced_outage_rate, scheduled_outage_rate, existing_fixed_o_m_cost, existing_overnight_cost)
+        #select 'Battery_Storage' as gen_tech, s.energy_source, s.max_age, s.variable_o_m, s.forced_outage_rate, s.scheduled_outage_rate, s.existing_fixed_o_m_cost, s.existing_overnight_cost
+        #from switch.scenario s where
+        #gen_tech='WT';
+
+        #UPDATE switch.generation_plant_technologies SET
+        #energy_source = 'Electricity',
+        #max_age = 10,
+        #forced_outage_rate = 0.02,
+        #scheduled_outage_rate = 0.0055,
+        #WHERE gen_tech='Battery_Storage';
+
+    print "\nAssigning default technology parameter values for forced outages, scheduled outages, and variable O&M..."
+    for param in ['forced_outage_rate','scheduled_outage_rate', 'variable_o_m']:
+        query = "UPDATE {PREFIX}generation_plant g SET {param} = t.{param}\
+                FROM {PREFIX}generation_plant_technologies t\
                 WHERE g.energy_source = t.energy_source AND\
-                g.gen_tech = t.gen_tech AND generation_plant_id BETWEEN {} AND\
-                {}".format(param, param, first_gen_id, last_gen_id)
+                g.gen_tech = t.gen_tech AND generation_plant_id BETWEEN {first_gen_id} AND\
+                {last_gen_id}".format(PREFIX = PREFIX, param=param, first_gen_id=first_gen_id, last_gen_id=last_gen_id)
         connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
         print "--Assigned {}".format(param)
 
-    # Manually assign maximum age for diablo canyon
-    query = "UPDATE generation_plant SET max_age = 40 WHERE name = 'Diablo Canyon'"
-    connect_to_db_and_run_query(query,
+    # Assign default max_age values for plants that don't have planned retirements
+    print "\nAssigning default technology max age values..."
+    for param in ['max_age']:
+        query = "UPDATE {PREFIX}generation_plant g SET {param} = t.{param}\
+                FROM {PREFIX}generation_plant_technologies t\
+                WHERE g.max_age = 0 AND\
+                g.energy_source = t.energy_source AND\
+                g.gen_tech = t.gen_tech AND generation_plant_id BETWEEN {first_gen_id} AND\
+                {last_gen_id}".format(PREFIX = PREFIX, param=param, first_gen_id=first_gen_id, last_gen_id=last_gen_id)
+        connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
+        print "--Assigned {}".format(param)
 
-    # Now, create scenario and assign ids for scenario #2
+    # Assign default values for 'storage_efficiency' = 0.75 and 'store_to_release_ratio'= 1 for battery storage
+    print "\nAssigning default technology values for battery storage..."
+    query = "UPDATE {PREFIX}generation_plant SET\
+        storage_efficiency = 0.75,\
+        store_to_release_ratio = 1\
+        WHERE energy_source = 'Electricity' AND\
+        gen_tech = 'Battery_Storage' AND\
+        generation_plant_id BETWEEN {first_gen_id} AND\
+        {last_gen_id}".format(PREFIX = PREFIX, first_gen_id=first_gen_id, last_gen_id=last_gen_id)
+    connect_to_db_and_run_query(query,
+        database='switch_wecc', user=user, password=password, quiet=True)
+    print "--Assigned battery storage technology parameters."
+
+    print "Adding scenario id numbers and descriptions to scenario mapping tables..."
+
+    # Copying a previous scenario and updating with new scenario id and description to hydro_simple_scenario table
+    query = "INSERT into {PREFIX}hydro_simple_scenario (hydro_simple_scenario_id, name, description) \
+            SELECT {hydro_scenario_id} as hydro_simple_scenario_id, name, description \
+            FROM {PREFIX}hydro_simple_scenario \
+            WHERE hydro_simple_scenario_id = 1".format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}hydro_simple_scenario\
+            SET name = 'EIA923 datasets 2004 until 2018',\
+                description = 'Pumped hydro units are modeled as simple turbines (summing netgen and electricity consumption columns).'\
+            WHERE hydro_simple_scenario_id = {hydro_scenario_id}".format(PREFIX = PREFIX,hydro_scenario_id = hydro_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated hydro_simple_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_cost_scenario table
+    query = "INSERT into {PREFIX}generation_plant_cost_scenario (generation_plant_cost_scenario_id, name, description) \
+            SELECT {generation_plant_cost_id} as generation_plant_cost_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_cost_scenario \
+            WHERE generation_plant_cost_scenario_id = 1".format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_cost_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018',\
+                description = 'Dataset from the EIA 860 and EIA 923 forms not aggregated by LZ. Approximately 2602 existing and 142 proposed generators.'\
+            WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}".format(PREFIX = PREFIX,generation_plant_cost_id = generation_plant_cost_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_cost_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_scenario table
+    query = "INSERT into {PREFIX}generation_plant_scenario (generation_plant_scenario_id, name, description) \
+            SELECT {gen_scenario_id} as generation_plant_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_scenario \
+            WHERE generation_plant_scenario_id = 1".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018',\
+                description = 'Dataset from the EIA 860 and EIA 923 forms not aggregated by LZ. Approximately 2602 existing and 142 proposed generators.'\
+            WHERE generation_plant_scenario_id = {gen_scenario_id}".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_existing_and_planned_scenario table
+    query = "INSERT into {PREFIX}generation_plant_existing_and_planned_scenario (generation_plant_existing_and_planned_scenario_id, name, description) \
+            SELECT {gen_scenario_id} as generation_plant_existing_and_planned_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_existing_and_planned_scenario \
+            WHERE generation_plant_existing_and_planned_scenario_id = 1".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_existing_and_planned_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018',\
+                description = 'Existing and proposed generators in the WECC region scraped from the EIA860 data form, without aggregation by LZ. Heat rates were processed from the EIA 923 form. The scraping package may be found at: https://github.com/RAEL-Berkeley/eia_scrape.'\
+            WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_existing_and_planned_scenario table with new scenario id"
+
+    # Now, create scenario and assign ids for this scenario
     # Get the actual list of ids in the table, since some rows were deleted
     # because no load zone could be assigned to those projects
     print "\nAssigning all individual plants to scenario id {}...".format(gen_scenario_id)
-    query = 'SELECT generation_plant_id FROM generation_plant\
-        WHERE generation_plant_id BETWEEN {} AND {}'.format(first_gen_id, last_gen_id)
+    query = 'SELECT generation_plant_id FROM {PREFIX}generation_plant\
+        WHERE generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id}'.format(PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     gen_plant_ids = connect_to_db_and_run_query(query,
                 database='switch_wecc', user=user, password=password, quiet=True)
     gen_plant_ids['generation_plant_scenario_id'] = gen_scenario_id
 
     connect_to_db_and_push_df(df=gen_plant_ids[['generation_plant_scenario_id','generation_plant_id']],
-        col_formats="(%s,%s)", table='generation_plant_scenario_member',
+        col_formats="(%s,%s)", table='{PREFIX}generation_plant_scenario_member'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully assigned pushed generation plants to a scenario!"
 
-    # Recover original NOT NULL constraint
-    query = 'ALTER TABLE "generation_plant" ALTER "load_zone_id" SET NOT NULL;'
+    # Restore original NOT NULL constraint
+    query = 'ALTER TABLE "{PREFIX}generation_plant" ALTER "load_zone_id" SET NOT NULL;'.format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
-    query = 'ALTER TABLE "generation_plant" ALTER "max_age" SET NOT NULL;'
+    query = 'ALTER TABLE "{PREFIX}generation_plant" ALTER "max_age" SET NOT NULL;'.format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
 
     # Get the list of indexes of plants actually uploaded
     print "\nAssigning build years to generation plants..."
-    query = 'SELECT * FROM generation_plant\
-        JOIN generation_plant_scenario_member USING (generation_plant_id)\
-        WHERE generation_plant_scenario_id = {}'.format(gen_scenario_id)
+    query = 'SELECT * FROM {PREFIX}generation_plant\
+        JOIN {PREFIX}generation_plant_scenario_member USING (generation_plant_id)\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     gens_in_db = connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
     gen_indexes_in_db = gens_in_db[['generation_plant_id','eia_plant_code','energy_source','gen_tech']]
 
-    # Create the df and upload it
+    # Creating the generation_plant_existing_and_planned_scenario_id as the same scenario as generation_plant_scenario_id
+    # Uploading the build years of the generators
     build_years_df = pd.merge(generators, gen_indexes_in_db,
         on=['eia_plant_code','energy_source','gen_tech'])[['generation_plant_id',
         'build_year','capacity']]
@@ -848,48 +1204,60 @@ def upload_generation_projects(year):
         'generation_plant_existing_and_planned_scenario_id','generation_plant_id',
         'build_year','capacity']]
     connect_to_db_and_push_df(df=build_years_df,
-        col_formats="(%s,%s,%s,%s)", table='generation_plant_existing_and_planned',
+        col_formats="(%s,%s,%s,%s)", table='{PREFIX}generation_plant_existing_and_planned'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully uploaded build years!"
 
+    # assigning a default 0 for fixed o_m and overnight costs in the generation_plant_cost table
     print "\nAssigning fixed and investment costs to generation plants..."
     cost_df = build_years_df.rename(columns={
         'generation_plant_existing_and_planned_scenario_id':
         'generation_plant_cost_scenario_id'}).drop('capacity', axis=1)
+    cost_df['generation_plant_cost_scenario_id'] = generation_plant_cost_id
     cost_df['fixed_o_m'] = 0
     cost_df['overnight_cost'] = 0
 
     connect_to_db_and_push_df(df=cost_df,
-        col_formats="(%s,%s,%s,%s,%s)", table='generation_plant_cost',
+        col_formats="(%s,%s,%s,%s,%s)", table='{PREFIX}generation_plant_cost'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully uploaded fixed and capital costs!"
 
     # Read hydro capacity factor data, merge with generators in the database, and upload
+    # monthly avg flow = monthly CF * nameplate capacity and monthly minimum flow is half the avg monthly flow
     print "\nUploading hydro capacity factors..."
     hydro_cf = read_output_csv('historic_hydro_capacity_factors_NARROW.tab').rename(
-        columns={'Plant Code':'eia_plant_code','Prime Mover':'gen_tech'})
+        columns={'Plant Code':'eia_plant_code','Prime Mover':'gen_tech'}).drop_duplicates()
     hydro_cf = pd.merge(hydro_cf,gen_indexes_in_db[['generation_plant_id','eia_plant_code','gen_tech']],
         on=['eia_plant_code','gen_tech'], how='inner')
     hydro_cf.rename(columns={'Month':'month','Year':'year'}, inplace=True)
     hydro_cf.loc[:,'hydro_avg_flow_mw'] = hydro_cf.loc[:,'Capacity Factor'] * hydro_cf.loc[:,'Nameplate Capacity (MW)']
     hydro_cf.loc[:,'hydro_min_flow_mw'] = hydro_cf.loc[:,'hydro_avg_flow_mw'] / 2
-    hydro_cf.loc[:,'hydro_simple_scenario_id'] = gen_scenario_id
+    hydro_cf.loc[:,'hydro_simple_scenario_id'] = hydro_scenario_id
+    fname = 'full_hydro_data.tab'
+    with open(os.path.join(outputs_directory, fname),'w') as f:
+        hydro_cf.to_csv(f, sep='\t', encoding='utf-8', index=False)
     hydro_cf = hydro_cf[['hydro_simple_scenario_id','generation_plant_id',
         'year','month','hydro_min_flow_mw','hydro_avg_flow_mw']]
     hydro_cf = hydro_cf.fillna(0.01)
+    fname = 'to_explore_weird_hydro_data.tab'
+    with open(os.path.join(outputs_directory, fname),'w') as f:
+        hydro_cf.to_csv(f, sep='\t', encoding='utf-8', index=False)
+    hydro_cf.drop_duplicates(subset=['hydro_simple_scenario_id','generation_plant_id', 'year','month'], inplace=True)
+    # drop any duplicates if hydro_cf has duplicates
 
     connect_to_db_and_push_df(df=hydro_cf,
-        col_formats="(%s,%s,%s,%s,%s,%s)", table='hydro_historical_monthly_capacity_factors',
+        col_formats="(%s,%s,%s,%s,%s,%s)", table='{PREFIX}hydro_historical_monthly_capacity_factors'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
-    print "Successfully uploaded hydro capacity factors!"
-
-
+    print "Successfully uploaded historical hydro capacity factors for 2004 to 2018!"
 
     print "\n-----------------------------"
     print "Aggregating projects by load zone..."
 
+    # Creating an aggregated version of the scenario above, aggregated by gen tech, energy source, HR, and load zone
+
     # First, group by load zone, gen tech, energy source and heat rate
     # (while calculating a capacity-weighted average heat rate)
+    # and aggregate the generators
     gens_in_db['hr_group'] = gens_in_db['full_load_heat_rate'].fillna(0).round()
     gens_in_db['full_load_heat_rate'] *= gens_in_db['capacity_limit_mw']
     gens_in_db_cols = gens_in_db.columns
@@ -901,7 +1269,7 @@ def upload_generation_projects(year):
     aggregated_gens['full_load_heat_rate'] /= aggregated_gens['capacity_limit_mw']
     aggregated_gens = aggregated_gens[gens_in_db_cols]
 
-    # Now, clean up columns
+    # Now, clean up columns and add a LZ prefix to the name of aggregated generators
     aggregated_gens['name'] = ('LZ_' + aggregated_gens['load_zone_id'].map(str) + '_' +
         aggregated_gens['gen_tech'] + '_' + aggregated_gens['energy_source'] + '_HR_' +
         aggregated_gens['hr_group'].map(int).map(str))
@@ -910,48 +1278,74 @@ def upload_generation_projects(year):
         axis=1, inplace=True)
     print "Aggregated into {} projects.".format(len(aggregated_gens))
 
-    # First, delete previously stored projects for the aggregated plants
-    gen_scenario_id = 3.0
+    # First, define gen_scenario_id as new_aggregated_gen_scenario_id, and
+    # delete previously stored projects for the aggregated plants
+     # Also define hydro simple scenario and generation_plant_cost scenario and delete previously stored projects for these scenario ids
 
-    query = 'DELETE FROM generation_plant_scenario_member\
-        WHERE generation_plant_scenario_id = {}'.format(gen_scenario_id)
+    gen_scenario_id = new_aggregated_gen_scenario_id
+    hydro_scenario_id = new_aggregated_hydro_simple_scenario_id
+    generation_plant_cost_id = new_aggregated_generation_plant_cost_id
+
+    query = 'DELETE FROM {PREFIX}generation_plant_scenario_member\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM generation_plant_existing_and_planned\
-        WHERE generation_plant_existing_and_planned_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}generation_plant_existing_and_planned\
+        WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM generation_plant_cost\
-        WHERE generation_plant_cost_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}generation_plant_cost\
+        WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}'.format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
-    query = 'DELETE FROM hydro_historical_monthly_capacity_factors\
-        WHERE hydro_simple_scenario_id = {}'.format(gen_scenario_id)
+    query = 'DELETE FROM {PREFIX}hydro_historical_monthly_capacity_factors\
+        WHERE hydro_simple_scenario_id = {hydro_scenario_id}'.format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    # Added these queries for the scenario mapping tables to add descriptions of new scenarios
+    query = 'DELETE FROM {PREFIX}hydro_simple_scenario\
+        WHERE hydro_simple_scenario_id = {hydro_scenario_id}'.format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_cost_scenario\
+        WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}'.format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_existing_and_planned_scenario\
+        WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+            database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = 'DELETE FROM {PREFIX}generation_plant_scenario\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
     # It is necessary to temporarily disable triggers when deleting from
     # generation_plant table, because of multiple fkey constraints
     query = 'SET session_replication_role = replica;\
-            DELETE FROM generation_plant\
+            DELETE FROM {PREFIX}generation_plant\
             WHERE generation_plant_id NOT IN\
-            (SELECT generation_plant_id FROM generation_plant_scenario_member);\
-            SET session_replication_role = DEFAULT;'
+            (SELECT generation_plant_id FROM {PREFIX}generation_plant_scenario_member);\
+            SET session_replication_role = DEFAULT;'.format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
-    print "\nDeleted previously stored projects for the load zone-aggregated EIA dataset (id 3). Pushing data..."
+    print "\nDeleted previously stored projects for the load zone-aggregated EIA dataset. Pushing data..."
 
     query = 'SELECT last_value FROM generation_plant_id_seq'
     first_gen_id = connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True).iloc[0,0] + 1
 
-    connect_to_db_and_push_df(df=aggregated_gens.drop(['hr_group','geom'], axis=1),
+    connect_to_db_and_push_df(df=aggregated_gens.drop(['hr_group','geom', 'substation_connection_geom', 'geom_area'], axis=1),
         col_formats=("(DEFAULT,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"
             "%s,%s,%s,%s,%s,%s,%s,%s,%s,NULL,NULL,NULL,NULL,NULL,NULL)"),
-        table='generation_plant',
+        table='{PREFIX}generation_plant'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully pushed aggregated project data!"
 
@@ -959,26 +1353,90 @@ def upload_generation_projects(year):
     last_gen_id = connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True).iloc[0,0]
 
+    print "Adding scenario id numbers and descriptions to scenario mapping tables..."
+
+    # Copying a previous scenario and updating with new scenario id and description to hydro_simple_scenario table
+    query = "INSERT into {PREFIX}hydro_simple_scenario (hydro_simple_scenario_id, name, description) \
+            SELECT {hydro_scenario_id} as hydro_simple_scenario_id, name, description \
+            FROM {PREFIX}hydro_simple_scenario \
+            WHERE hydro_simple_scenario_id = 1".format(PREFIX = PREFIX, hydro_scenario_id = hydro_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}hydro_simple_scenario\
+            SET name = 'EIA923 datasets 2004 until 2018 Aggregated by LZ',\
+                description = 'Same as scenario id 19, but aggregated by load zone.'\
+            WHERE hydro_simple_scenario_id = {hydro_scenario_id}".format(PREFIX = PREFIX,hydro_scenario_id = hydro_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated hydro_simple_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_cost_scenario table
+    query = "INSERT into {PREFIX}generation_plant_cost_scenario (generation_plant_cost_scenario_id, name, description) \
+            SELECT {generation_plant_cost_id} as generation_plant_cost_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_cost_scenario \
+            WHERE generation_plant_cost_scenario_id = 1".format(PREFIX = PREFIX, generation_plant_cost_id = generation_plant_cost_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_cost_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018 Aggregated by LZ',\
+                description = 'Dataset from the EIA 860 and EIA 923 forms aggregated by LZ.'\
+            WHERE generation_plant_cost_scenario_id = {generation_plant_cost_id}".format(PREFIX = PREFIX,generation_plant_cost_id = generation_plant_cost_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_cost_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_scenario table
+    query = "INSERT into {PREFIX}generation_plant_scenario (generation_plant_scenario_id, name, description) \
+            SELECT {gen_scenario_id} as generation_plant_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_scenario \
+            WHERE generation_plant_scenario_id = 1".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018 Aggregated by LZ',\
+                description = 'Dataset from the EIA 860 and EIA 923 forms aggregated by LZ.'\
+            WHERE generation_plant_scenario_id = {gen_scenario_id}".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_scenario table with new scenario id"
+
+    # Copying a previous scenario and updating with new scenario id and description to generation_plant_existing_and_planned_scenario table
+    query = "INSERT into {PREFIX}generation_plant_existing_and_planned_scenario (generation_plant_existing_and_planned_scenario_id, name, description) \
+            SELECT {gen_scenario_id} as generation_plant_existing_and_planned_scenario_id, name, description \
+            FROM {PREFIX}generation_plant_existing_and_planned_scenario \
+            WHERE generation_plant_existing_and_planned_scenario_id = 1".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+
+    query = "UPDATE {PREFIX}generation_plant_existing_and_planned_scenario\
+            SET name = 'EIA-WECC Existing and Proposed 2018 Aggregated by LZ',\
+                description = 'Existing and proposed generators in the WECC region scraped from the EIA860 data form, aggregated by LZ. Heat rates were processed from the EIA 923 form. The scraping package may be found at: https://github.com/RAEL-Berkeley/eia_scrape'\
+            WHERE generation_plant_existing_and_planned_scenario_id = {gen_scenario_id}".format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id )
+    connect_to_db_and_run_query(query,
+                database='switch_wecc', user=user, password=password, quiet=True)
+    print "Updated generation_plant_existing_and_planned_scenario table with new scenario id"
+
+    #Now assigning all generators and their costs to the scenario
     print "\nAssigning all aggregated plants to scenario id {}...".format(gen_scenario_id)
-    query = 'INSERT INTO generation_plant_scenario_member\
-    (SELECT {}, generation_plant_id FROM generation_plant\
-        WHERE generation_plant_id BETWEEN {} AND {})'.format(
-            gen_scenario_id,first_gen_id, last_gen_id)
+
+    query = 'INSERT INTO {PREFIX}generation_plant_scenario_member\
+    (SELECT {gen_scenario_id}, generation_plant_id FROM {PREFIX}generation_plant\
+        WHERE generation_plant_id BETWEEN {first_gen_id} AND {last_gen_id})'.format(gen_scenario_id = gen_scenario_id, PREFIX = PREFIX, first_gen_id = first_gen_id, last_gen_id = last_gen_id)
     connect_to_db_and_run_query(query,
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully assigned pushed generation plants to a scenario!"
 
-    query = 'SELECT last_value FROM generation_plant_id_seq'
-    last_gen_id = connect_to_db_and_run_query(query,
-        database='switch_wecc', user=user, password=password, quiet=True)
-
     print "\nAssigning build years to generation plants..."
-    query = 'SELECT * FROM generation_plant\
-        JOIN generation_plant_scenario_member USING (generation_plant_id)\
-        WHERE generation_plant_scenario_id = {}'.format(gen_scenario_id)
+    query = 'SELECT * FROM {PREFIX}generation_plant\
+        JOIN {PREFIX}generation_plant_scenario_member USING (generation_plant_id)\
+        WHERE generation_plant_scenario_id = {gen_scenario_id}'.format(PREFIX = PREFIX, gen_scenario_id = gen_scenario_id)
     aggregated_gens_in_db = connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
+    #assigning same gen_scenario_id to generation_plant_existing_and_planned_scenario_id
     aggregated_gens_in_db['hr_group'] = aggregated_gens_in_db['full_load_heat_rate'].fillna(0).round()
     aggregated_gens_in_db['generation_plant_existing_and_planned_scenario_id'] = gen_scenario_id
     gens_in_db = pd.merge(gens_in_db, generators[['eia_plant_code','energy_source',
@@ -990,6 +1448,7 @@ def upload_generation_projects(year):
         'generation_plant_id','build_year','capacity']]
     aggregated_gens_bld_yrs_cols = list(aggregated_gens_bld_yrs.columns)
 
+    #keep the most recent build year of the aggregation of generators
     gb = aggregated_gens_bld_yrs.groupby(aggregated_gens_bld_yrs_cols[:-1])
     aggregated_gens_bld_yrs = gb.agg(
         {col:(sum if col=='capacity' else 'max')
@@ -998,7 +1457,7 @@ def upload_generation_projects(year):
 
     connect_to_db_and_push_df(df=aggregated_gens_bld_yrs,
         col_formats="(%s,%s,%s,%s)",
-        table='generation_plant_existing_and_planned',
+        table='{PREFIX}generation_plant_existing_and_planned'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully pushed aggregated project build years data!"
 
@@ -1006,15 +1465,16 @@ def upload_generation_projects(year):
     aggregated_gens_costs = aggregated_gens_bld_yrs.rename(columns={
         'generation_plant_existing_and_planned_scenario_id':
         'generation_plant_cost_scenario_id'}).drop('capacity', axis=1)
+    aggregated_gens_costs['generation_plant_cost_scenario_id'] = generation_plant_cost_id
     aggregated_gens_costs['fixed_o_m'] = 0
     aggregated_gens_costs['overnight_cost'] = 0
 
     connect_to_db_and_push_df(df=aggregated_gens_costs,
-        col_formats="(%s,%s,%s,%s,%s)", table='generation_plant_cost',
+        col_formats="(%s,%s,%s,%s,%s)", table='{PREFIX}generation_plant_cost'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully uploaded fixed and capital costs!"
 
-    print "\nUploading hydro capacity factors..."
+    print "\nAggregating and uploading hydro capacity factors..."
     agg_hydro_cf = read_output_csv('historic_hydro_capacity_factors_NARROW.tab').rename(
         columns={'Plant Code':'eia_plant_code','Prime Mover':'gen_tech',
         'Month':'month','Year':'year'})
@@ -1025,7 +1485,7 @@ def upload_generation_projects(year):
     agg_hydro_cf = pd.merge(agg_hydro_cf, gens_in_db[[
         'eia_plant_code','gen_tech','load_zone_id','generation_plant_id']].drop_duplicates(),
         on=['eia_plant_code', 'gen_tech'], how='inner')
-    agg_hydro_cf['hydro_simple_scenario_id'] = gen_scenario_id
+    agg_hydro_cf['hydro_simple_scenario_id'] = hydro_scenario_id
     gb = agg_hydro_cf.groupby(['load_zone_id','gen_tech','month','year'])
     agg_hydro_cf = gb.agg(
         {col:(sum if col in ['hydro_min_flow_mw','hydro_avg_flow_mw'] else 'max')
@@ -1035,10 +1495,10 @@ def upload_generation_projects(year):
         on=['load_zone_id', 'gen_tech'], how='inner', suffixes=('','_y'))
     agg_hydro_cf = agg_hydro_cf[['hydro_simple_scenario_id','generation_plant_id','year','month',
         'hydro_min_flow_mw','hydro_avg_flow_mw']]
-    agg_hydro_cf = agg_hydro_cf.fillna(0.01)    
+    agg_hydro_cf = agg_hydro_cf.fillna(0.01)
 
     connect_to_db_and_push_df(df=agg_hydro_cf,
-        col_formats="(%s,%s,%s,%s,%s,%s)", table='hydro_historical_monthly_capacity_factors',
+        col_formats="(%s,%s,%s,%s,%s,%s)", table='{PREFIX}hydro_historical_monthly_capacity_factors'.format(PREFIX = PREFIX),
         database='switch_wecc', user=user, password=password, quiet=True)
     print "Successfully uploaded hydro capacity factors!"
 
@@ -1050,17 +1510,26 @@ def assign_var_cap_factors():
 
     Capacity factors are calculated as the average for all plants from the old
     AMPL dataset for each load zone. These load zone profiles are then assigned
-    to all new EIA projects located there.
+    to all new EIA projects located in that load zone.
 
-    I later realized that several load zones had some missing PV capacity factors
-    for the first hours of each year. So, I set all capacity factors between
-    00:00 and 08:00 to 0. Then, I noticed that the missing capacity factors
-    were actually caused because all the dataset was shifted 7 hours ahead from
-    the new timepoint definitions. So, this is later corrected by shifting all
-    new capacity factors 7 hours earlier.
+    This is completed for only the generation_plants that are members of the new
+    scenarios added in this script.
+
+    Note: The capacity factors for residential PV, commercial PV, and
+    central (utility-scale) PV are all averaged together for the solar PV capacity
+    factor. This assumption may need to be revised later to account for differences
+    between residential and utility scale capacity factors.
+
+    Note: The capacity factors for solar in the AMPL data is in UTC (7 hrs ahead).
+    This is consistent with the load data, which is also in UTC.
+    In the previous verion of this script, there is a correction applied to the data
+    by shifting all new capacity factors 7 hours earlier. However, this appears to have been
+    already completed for the AMPL data and therefore, this shift is no longer necessary and
+    the associated part of the code has been deleted in the 2020 update.
 
     All these processes take significant time, so it is recommended to run
-    this script through a sturdy SSH tunnel.
+    this script through a sturdy SSH tunnel (or use a screen and SSH directly into
+     db to run the queries).
 
     """
 
@@ -1068,87 +1537,67 @@ def assign_var_cap_factors():
     password = getpass.getpass('Enter database password for user {}:'.format(user))
     print "\nWill assign variable capacity factors for WIND projects"
     print "(May take significant time)\n"
+
     # Assign average AMPL wind profile of each load zone to all projects in that zone
+    # Technology id 4 is for on-shore wind (5 is for offshore wind but isn't used here)
+
     for zone in range(1,51):
         print "Load zone {}...".format(zone)
-        query = "INSERT INTO variable_capacity_factors\
+        print '-- Assign average AMPL wind profile for zone {}'.format(zone)
+        query = "INSERT INTO {PREFIX}variable_capacity_factors\
                 (SELECT generation_plant_id, timepoint_id, timestamp_utc, cap_factor, 1\
-                FROM generation_plant\
+                FROM {PREFIX}generation_plant\
+                JOIN {PREFIX}generation_plant_scenario_member USING (generation_plant_id)\
                 JOIN(\
                 SELECT area_id, timepoint_id, timestamp_utc, avg(cap_factor) AS cap_factor, 1\
-                FROM temp_ampl__proposed_projects_v3\
-                JOIN temp_variable_capacity_factors_historical USING (project_id)\
-                JOIN temp_load_scenario_historic_timepoints ON (hour=historic_hour)\
-                JOIN raw_timepoint ON (timepoint_id = raw_timepoint_id)\
-                WHERE area_id = {} AND technology_id = 4\
+                FROM {PREFIX}temp_ampl__proposed_projects_v3\
+                JOIN {PREFIX}temp_variable_capacity_factors_historical USING (project_id)\
+                JOIN {PREFIX}temp_load_scenario_historic_timepoints ON (hour=historic_hour)\
+                JOIN {PREFIX}raw_timepoint ON (timepoint_id = raw_timepoint_id)\
+                WHERE area_id = {zone} AND technology_id = 4\
                 GROUP BY 1,2,3\
                 ORDER BY 1,2\
                 ) AS factors ON (area_id = load_zone_id)\
-                WHERE gen_tech = 'WT')".format(zone)
+                WHERE gen_tech = 'WT' \
+                AND generation_plant_scenario_id IN ({gen_scenario_id1},{gen_scenario_id2}));\n\n".format(PREFIX = PREFIX,
+                gen_scenario_id1 = new_disaggregated_gen_scenario_id,
+                gen_scenario_id2 = new_aggregated_gen_scenario_id,
+                zone = zone)
+        print query
         connect_to_db_and_run_query(query,
                 database='switch_wecc', user=user, password=password, quiet=True)
-        print "Successfully assigned factors to projects in load zone {}.".format(zone)
+        print "Successfully assigned cap factors to wind projects in load zone {}.".format(zone)
+
+    # Technology id 6 is for residential solar, 25 is for commercial PV, and 26 is for central PV
 
     print "\nWill assign variable capacity factors for SOLAR PV projects"
     print "(May take significant time)\n"
     for zone in range(1,51):
         print "Load zone {}...".format(zone)
-        query = "INSERT INTO variable_capacity_factors\
+        print '-- Assign variable capacity factors for solar PV projects in zone {}'.format(zone)
+        query = "INSERT INTO {PREFIX}variable_capacity_factors\
                 (SELECT generation_plant_id, timepoint_id, timestamp_utc, cap_factor, 1\
-                FROM generation_plant\
+                FROM {PREFIX}generation_plant\
+                JOIN {PREFIX}generation_plant_scenario_member USING (generation_plant_id)\
                 JOIN(\
                 SELECT area_id, timepoint_id, timestamp_utc, avg(cap_factor) AS cap_factor, 1\
-                FROM temp_ampl__proposed_projects_v3\
-                JOIN temp_variable_capacity_factors_historical USING (project_id)\
-                JOIN temp_load_scenario_historic_timepoints ON (hour=historic_hour)\
-                JOIN raw_timepoint ON (timepoint_id = raw_timepoint_id)\
-                WHERE area_id = {} AND technology_id IN (6,25,26)\
+                FROM {PREFIX}temp_ampl__proposed_projects_v3\
+                JOIN {PREFIX}temp_variable_capacity_factors_historical USING (project_id)\
+                JOIN {PREFIX}temp_load_scenario_historic_timepoints ON (hour=historic_hour)\
+                JOIN {PREFIX}raw_timepoint ON (timepoint_id = raw_timepoint_id)\
+                WHERE area_id = {zone} AND technology_id IN (6,25,26)\
                 GROUP BY 1,2,3\
                 ORDER BY 1,2\
                 ) AS factors ON (area_id = load_zone_id)\
-                WHERE gen_tech = 'PV')".format(zone)
+                WHERE gen_tech = 'PV'\
+                AND generation_plant_scenario_id IN ({gen_scenario_id1},{gen_scenario_id2}));\n\n".format(PREFIX = PREFIX,
+                gen_scenario_id1 = new_disaggregated_gen_scenario_id,
+                gen_scenario_id2 = new_aggregated_gen_scenario_id,
+                zone = zone)
+        print query
         connect_to_db_and_run_query(query,
                 database='switch_wecc', user=user, password=password, quiet=True)
-        print "Successfully assigned factors to projects in load zone {}.".format(zone)
-
-    print "\nSetting all capacity factors for January 1st 00:00-8:00 hrs to 0.0"
-    for zone in range(1,51):
-        query = "delete from variable_capacity_factors cf\
-        using generation_plant gp\
-        where gp.generation_plant_id = cf.generation_plant_id and\
-        gen_tech = 'PV' and load_zone_id={} and\
-        extract(day from timestamp_utc) = 1\
-        and extract(month from timestamp_utc) = 1\
-        and extract(hour from timestamp_utc) between 0 and 8".format(zone)
-        connect_to_db_and_run_query(query,
-            database='switch_wecc', user=user, password=password, quiet=True)
-        print "Deleted existing cap factors for zone {} in that interval.".format(zone)
-
-        query = "INSERT into variable_capacity_factors\
-        (select generation_plant_id, timepoint_id, timestamp_utc, 0.0, 1\
-        from temp_load_scenario_historic_timepoints\
-        join raw_timepoint on (raw_timepoint_id=timepoint_id)\
-        cross join generation_plant\
-        where gen_tech = 'PV'\
-        and load_zone_id = {}\
-        and extract(day from timestamp_utc) = 1\
-        and extract(month from timestamp_utc) = 1\
-        and extract(hour from timestamp_utc) between 0 and 8)".format(zone)
-        connect_to_db_and_run_query(query,
-            database='switch_wecc', user=user, password=password, quiet=True)
-        print "Inserted values of 0.0."
-
-    # Replace the dummy values of 0.0 by moving all capacity factors 7 hours ahead
-    # This is necessary due to a mismatch with the old AMPL factors
-    print "Moving PV capacity factors 7 hours ahead. Could take a long while..."
-    query = "UPDATE variable_capacity_factors cf\
-            set capacity_factor = cf2.capacity_factor\
-            from variable_capacity_factors cf2 join generation_plant using (generation_plant_id)\
-            where gen_tech = 'PV' and\
-            cf.generation_plant_id = cf2.generation_plant_id and\
-            cf.raw_timepoint_id + 7 = cf2.raw_timepoint_id;"
-    connect_to_db_and_run_query(query,
-            database='switch_wecc', user=user, password=password, quiet=True)
+        print "Successfully assigned cap factors to solar projects in load zone {}.".format(zone)
 
 
 def others():
@@ -1159,7 +1608,7 @@ def others():
     were mistakenly not calculated (though only amount to 60 MW).
 
     Other (OT) technologies were assigned a default gas energy source, but were
-    not calculated heat rates, so their are assigned the average heat rate for
+    not calculated heat rates, so they are assigned the average heat rate for
     gas plants (OT only amounts to around 40 MW).
 
     Nan hydro capacity factors are replaced by 0.01.
@@ -1169,63 +1618,69 @@ def others():
     Null connection cost parameters are replaced by 0.
 
     """
-
+    try:
+        user = os.environ['SWITCH_USERNAME']
+        password = os.environ['SWITCH_PASSWORD']
+    except KeyError:
+        user = getpass.getpass('Enter username for the database:')
+        password = getpass.getpass('Enter database password for user {}:'.format(user))
     # Fuel cells ('FC') were not calculated and assigned heat rates
-    # These sum up to 63 MW of capacity in WECC
+    # These sum up to about 60 MW of capacity in WECC
     # Cleanest option is to remove them from the current runs:
-    query = "CREATE TABLE switch.fuel_cell_generation_plant_backup (like generation_plant);\
-        INSERT INTO fuel_cell_generation_plants\
-        (SELECT * FROM generation_plant WHERE gen_tech = 'FC');\
-        DELETE FROM generation_plant_scenario_member gpsm USING generation_plant gp\
+    query = "INSERT INTO {PREFIX}fuel_cell_generation_plant_backup\
+        (SELECT * FROM {PREFIX}generation_plant WHERE gen_tech = 'FC');\
+        DELETE FROM {PREFIX}generation_plant_scenario_member gpsm USING {PREFIX}generation_plant gp\
         WHERE gp.generation_plant_id = gpsm.generation_plant_id\
         AND gen_tech = 'FC';\
-        DELETE FROM generation_plant_cost gpc USING generation_plant gp\
+        DELETE FROM {PREFIX}generation_plant_cost gpc USING {PREFIX}generation_plant gp\
         WHERE gp.generation_plant_id = gpc.generation_plant_id\
         AND gen_tech = 'FC';\
-        DELETE FROM generation_plant_existing_and_planned gpep USING generation_plant gp\
+        DELETE FROM {PREFIX}generation_plant_existing_and_planned gpep USING {PREFIX}generation_plant gp\
         WHERE gp.generation_plant_id = gpep.generation_plant_id\
         AND gen_tech = 'FC';\
-        DELETE FROM generation_plant WHERE gen_tech = 'FC';"
+        DELETE FROM {PREFIX}generation_plant WHERE gen_tech = 'FC';".format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
     # Others ('OT') also do not have an assigned heat rate. Assign an average.
-    query = "UPDATE generation_plant set full_load_heat_rate = \
+    query = "UPDATE {PREFIX}generation_plant set full_load_heat_rate = \
         (select avg(full_load_heat_rate)\
-        from generation_plant\
-        join generation_plant_scenario_member using (generation_plant_id)\
+        from {PREFIX}generation_plant\
+        join {PREFIX}generation_plant_scenario_member using (generation_plant_id)\
         where energy_source = 'Gas'\
-        and generation_plant_scenario_id = 2)\
-        where gen_tech = 'OT' and energy_source = 'Gas'"
+        and generation_plant_scenario_id IN ({gen_scenario_id1},{gen_scenario_id2}))\
+        where gen_tech = 'OT' and energy_source = 'Gas'".format(PREFIX = PREFIX, gen_scenario_id1 = new_disaggregated_gen_scenario_id, gen_scenario_id2 = new_aggregated_gen_scenario_id )
     connect_to_db_and_run_query(query,
             database='switch_wecc', user=user, password=password, quiet=True)
 
     # Replace 'NaN's with 'Null's
     # (NaNs result from the aggregation process)
-    cols_to_replace_nans = ['connect_cost_per_mw','hydro_efficiency','min_build_capacity',
+    # Added full_load_hr to this list becauase there are NaNs for renewable sources
+    cols_to_replace_nans = ['connect_cost_per_mw','full_load_heat_rate','hydro_efficiency','min_build_capacity',
                             'unit_size','storage_efficiency','store_to_release_ratio',
                             'min_load_fraction','startup_fuel','startup_om',
                             'ccs_capture_efficiency', 'ccs_energy_load']
     for col in cols_to_replace_nans:
-        query = "UPDATE generation_plant SET {c} = Null WHERE {c} = 'NaN'".format(c=col)
+        query = "UPDATE {PREFIX}generation_plant SET {c} = Null WHERE {c} = 'NaN'".format(PREFIX = PREFIX, c=col)
         connect_to_db_and_run_query(query,
                 database='switch_wecc', user=user, password=password, quiet=True)
         print "Replaced NaNs in column '{}'".format(col)
 
     # Replace Nulls with zeros where Switch expects a number
-    query = "UPDATE generation_plant\
+    query = "UPDATE {PREFIX}generation_plant\
             SET connect_cost_per_mw = 0.0\
-            WHERE connect_cost_per_mw is Null"
+            WHERE connect_cost_per_mw is Null".format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query,
                 database='switch_wecc', user=user, password=password, quiet=True)
 
 
 if __name__ == "__main__":
-    finish_project_processing(2015)
-    # upload_generation_projects(2015)
-    # assign_var_cap_factors()
-    # others()
-
+    finish_project_processing(2018)
+    upload_generation_projects(2018)
+    assign_var_cap_factors()
+    others()
+    compare_generation_projects_scenario_data_by_energy_source(2.0, 19.0)
+    compare_generation_projects_scenario_data_by_energy_source(3.0, 20.0)
 
 
 def assign_states_to_counties():
@@ -1282,14 +1737,14 @@ def assign_states_to_counties():
         'WY': 'Wyoming'
     }
 
-    query = 'UPDATE us_counties uc SET state_name = cs.state\
+    query = 'UPDATE {PREFIX}us_counties uc SET state_name = cs.state\
         FROM (SELECT DISTINCT c.name, state, statefp, state_fips, c.gid\
-        FROM us_counties c join us_states s ON c.statefp=s.state_fips) cs\
-        WHERE cs.gid = uc.gid'
+        FROM {PREFIX}us_counties c join {PREFIX}us_states s ON c.statefp=s.state_fips) cs\
+        WHERE cs.gid = uc.gid'.format(PREFIX = PREFIX)
     connect_to_db_and_run_query(query, database='switch_wecc', user=user, password=password)
 
 
     for state_abr, state_name in state_dict.iteritems():
-        query = "UPDATE us_counties SET state_name = '{}' WHERE state_name = '{}'".format(
-            state_abr, state_name)
+        query = "UPDATE {PREFIX}us_counties SET state_name = '{state_abr}' WHERE state_name = '{state_name}'".format(
+            PREFIX = PREFIX, state_abr = state_abr, state_name = state_name)
         connect_to_db_and_run_query(query, database='switch_wecc', user=user, password=password)

--- a/queries_to_create_db_backup_tables_for_testing.sql
+++ b/queries_to_create_db_backup_tables_for_testing.sql
@@ -1,0 +1,115 @@
+-- Copyright 2020. All rights reserved. Written in 2020 by Julia Szinai
+-- Licensed under the Apache License, Version 2.0 which is in LICENSE.txt
+
+-- This script creates backup tables (copies of the original db tables) of all the tables that are modified and/or used in the EIA_scrape scripts. 
+
+-- This script is not meant to be executed as is, but rather is a way to document the queries that were run as part of the process of testing the updated 
+-- EIA_scrape scripts. Therefore there is a syntax error on purpose in the first query which will cause the script to break if it is executed as is. 
+-- Instead, SSH into the db, copy and run these individual queries in different screens to create backup tables before running and testing the EIA_scrape scripts.
+-- It is useful to run the queries in screens because some of the queries take a long time to run (especially query 13 and 14)
+
+-- Broad steps on how to implement:
+-- 1. Create backup tables with a prefix in the name (in this case jsz_backup was the prefix used) that are copies of the original db tables that are modified in the 
+-- database_interface.py (from https://github.com/RAEL-Berkeley/eia_scrape/)
+
+-- This loop makes it easier to create the queries for all the backup table creation
+-- CREATE_BACKUP_TABLES = ';\n'.join(
+--         "DROP TABLE {PREFIX}{ORIG_TABLE}; CREATE TABLE {PREFIX}{ORIG_TABLE} (LIKE {ORIG_TABLE} INCLUDING INDEXES INCLUDING DEFAULTS); INSERT INTO {PREFIX}{ORIG_TABLE} SELECT * FROM {ORIG_TABLE}".format(PREFIX=PREFIX, ORIG_TABLE=ORIG_TABLE) for ORIG_TABLE in (
+--             'generation_plant',
+--             'generation_plant_cost',
+--             'generation_plant_existing_and_planned',
+--             'generation_plant_scenario_member',
+--             'generation_plant_technologies',
+--             'hydro_historical_monthly_capacity_factors',
+--             'load_zone',
+--             'raw_timepoint',
+--             'temp_ampl__proposed_projects_v3',
+--             'temp_load_scenario_historic_timepoints',
+--             'temp_variable_capacity_factors_historical',
+--             'us_counties',
+--             'us_states',
+--             'variable_capacity_factors',
+--         )
+--     ) + ';'
+
+-- 2. Run the scrape.py script.
+-- 3. Run the database_interface.py script on the backup tables and create a new scenario 17 in the backup tables exactly as before but with the updated set of EIA input files out to 2018
+-- 3. Compare the new scenario in the backup tables to the original scenario 2 
+-- 4. If OK, recreate backup tables that are copies of the original db tables
+-- 5. Re-run the database_interface.py script on the original tables to create the same new scenario 18
+
+-- To create backup tables:
+-- 1. Open terminal and run these commands:
+-- ssh jszinai@switch-db2.erg.berkeley.edu
+-- 2. For each query create a screen, so it can run and not have the connection reset:
+-- screen -S query_#
+-- 3. Connect to the postgres db:
+-- psql -d switch_wecc
+-- 4. Copy query
+-- 5. To detach a “screen” session: 
+-- Ctrl-A then D
+-- To reattach a “screen” session:
+-- screen -r
+-- Ctrl-D and then exit to end a screen after a query is done
+-- 6. To check status of queries:
+-- Create a check_queries screen and run this:
+-- Select * from pg_stat_activity
+
+-- This is a dummy query meant to create a syntax error to prevent this script from being run as is:
+SELECT 1
+FROM ; 
+
+-- Queries to create backup tables:
+-- Query 1:
+DROP TABLE switch.jsz_backup_generation_plant; CREATE TABLE switch.jsz_backup_generation_plant (LIKE switch.generation_plant INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant SELECT * FROM switch.generation_plant;                      	
+
+-- Query 2:
+DROP TABLE switch.jsz_backup_generation_plant_cost; CREATE TABLE switch.jsz_backup_generation_plant_cost (LIKE switch.generation_plant_cost INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_cost SELECT * FROM switch.generation_plant_cost;
+
+-- Query 3:
+DROP TABLE switch.jsz_backup_generation_plant_existing_and_planned; CREATE TABLE switch.jsz_backup_generation_plant_existing_and_planned (LIKE switch.generation_plant_existing_and_planned INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_existing_and_planned SELECT * FROM switch.generation_plant_existing_and_planned;                
+
+-- Query 4:                     	
+DROP TABLE switch.jsz_backup_generation_plant_scenario_member; CREATE TABLE switch.jsz_backup_generation_plant_scenario_member (LIKE switch.generation_plant_scenario_member INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_scenario_member SELECT * FROM switch.generation_plant_scenario_member;
+
+-- Query 5:
+DROP TABLE switch.jsz_backup_generation_plant_technologies; CREATE TABLE switch.jsz_backup_generation_plant_technologies (LIKE switch.generation_plant_technologies INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_technologies SELECT * FROM switch.generation_plant_technologies;
+
+-- Query 6:
+DROP TABLE switch.jsz_backup_hydro_historical_monthly_capacity_factors; CREATE TABLE switch.jsz_backup_hydro_historical_monthly_capacity_factors (LIKE switch.hydro_historical_monthly_capacity_factors INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_hydro_historical_monthly_capacity_factors SELECT * FROM switch.hydro_historical_monthly_capacity_factors;
+
+-- Query 7:
+DROP TABLE switch.jsz_backup_load_zone; CREATE TABLE switch.jsz_backup_load_zone (LIKE switch.load_zone INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_load_zone SELECT * FROM switch.load_zone;
+
+-- Query 8:
+DROP TABLE switch.jsz_backup_raw_timepoint; CREATE TABLE switch.jsz_backup_raw_timepoint (LIKE switch.raw_timepoint INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_raw_timepoint SELECT * FROM switch.raw_timepoint;
+
+-- Query 9:
+DROP TABLE switch.jsz_backup_temp_ampl__proposed_projects_v3; CREATE TABLE switch.jsz_backup_temp_ampl__proposed_projects_v3 (LIKE switch.temp_ampl__proposed_projects_v3 INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_temp_ampl__proposed_projects_v3 SELECT * FROM switch.temp_ampl__proposed_projects_v3;
+
+-- Query 10:
+DROP TABLE switch.jsz_backup_temp_load_scenario_historic_timepoints; CREATE TABLE switch.jsz_backup_temp_load_scenario_historic_timepoints (LIKE switch.temp_load_scenario_historic_timepoints INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_temp_load_scenario_historic_timepoints SELECT * FROM switch.temp_load_scenario_historic_timepoints;
+
+-- Query 11:
+DROP TABLE switch.jsz_backup_us_counties; CREATE TABLE switch.jsz_backup_us_counties (LIKE switch.us_counties INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_us_counties SELECT * FROM switch.us_counties;
+-- Query 12:
+DROP TABLE switch.jsz_backup_us_states; CREATE TABLE switch.jsz_backup_us_states (LIKE switch.us_states INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_us_states SELECT * FROM switch.us_states;
+
+-- Query 13: (this takes a long time to run)
+DROP TABLE switch.jsz_backup_variable_capacity_factors; CREATE TABLE switch.jsz_backup_variable_capacity_factors (LIKE switch.variable_capacity_factors INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_variable_capacity_factors SELECT * FROM switch.variable_capacity_factors;
+
+-- Query 14:
+DROP TABLE switch.jsz_backup_temp_variable_capacity_factors_historical; CREATE TABLE switch.jsz_backup_temp_variable_capacity_factors_historical (LIKE switch.temp_variable_capacity_factors_historical INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_temp_variable_capacity_factors_historical SELECT * FROM switch.temp_variable_capacity_factors_historical;   	
+
+-- Scenario mapping tables:
+-- Query 15:
+DROP TABLE switch.jsz_backup_generation_plant_cost_scenario; CREATE TABLE switch.jsz_backup_generation_plant_cost_scenario (LIKE switch.generation_plant_cost_scenario INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_cost_scenario SELECT * FROM switch.generation_plant_cost_scenario;
+
+-- Query 16:
+DROP TABLE switch.jsz_backup_generation_plant_existing_and_planned_scenario; CREATE TABLE switch.jsz_backup_generation_plant_existing_and_planned_scenario (LIKE switch.generation_plant_existing_and_planned_scenario INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_existing_and_planned_scenario SELECT * FROM switch.generation_plant_existing_and_planned_scenario;
+
+-- Query 17:
+DROP TABLE switch.jsz_backup_hydro_simple_scenario; CREATE TABLE switch.jsz_backup_hydro_simple_scenario (LIKE switch.hydro_simple_scenario INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_hydro_simple_scenario SELECT * FROM switch.hydro_simple_scenario;
+
+-- Query 18:
+DROP TABLE switch.jsz_backup_generation_plant_scenario; CREATE TABLE switch.jsz_backup_generation_plant_scenario (LIKE switch.generation_plant_scenario INCLUDING INDEXES INCLUDING DEFAULTS INCLUDING CONSTRAINTS); INSERT INTO switch.jsz_backup_generation_plant_scenario SELECT * FROM switch.generation_plant_scenario;

--- a/scrape.py
+++ b/scrape.py
@@ -1,7 +1,8 @@
-# Copyright 2017. All rights reserved. See AUTHORS.txt
+ # Copyright 2020. All rights reserved. See AUTHORS.txt
 # Licensed under the Apache License, Version 2.0 which is in LICENSE.txt
+# Edited in 2020 from original 2017 version by Julia Szinai
 """
-Scrape data on existing and planned generators in the United States from the 
+Scrape data on existing and planned generators in the United States from the
 Energy Information Agency's EIA860 and EIA923 forms (and their older versions).
 
 Enables sequential aggregation of generator data by multiple criteria and
@@ -24,6 +25,7 @@ import csv, os, re
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from simpledbf import Dbf5
 from calendar import monthrange
 
 from utils import download_file, download_metadata_fields, unzip, append_historic_output_to_csv
@@ -34,25 +36,51 @@ other_data_directory = 'other_data'
 outputs_directory = 'processed_data'
 download_log_path = os.path.join(unzip_directory, 'download_log.csv')
 REUSE_PRIOR_DOWNLOADS = True
-CLEAR_PRIOR_OUTPUTS = True
+CLEAR_PRIOR_OUTPUTS = False
 REWRITE_PICKLES = False
 AGGREGATE_COAL = True
-start_year, end_year = 2010, 2015
+start_year, end_year = 2004, 2018
+end_month = 'may'
 fuel_prime_movers = ['ST','GT','IC','CA','CT','CS','CC']
+#ST = Steam turbine,
+# GT = Gas turbine (includes jet engine),
+# IC = Internal Combustion Engine (diesel, piston, reciprocating)
+#CA = Combined Cycle Steam Part, CT = Combined Cycle Combustion Turbine Part,
+#CS = Combined Cycle Single Shaft (combustion turbine and steam turbine share single generator)
+#CC = Combined Cycle Total Unit (use only for plants/generators that are in
+#planning stage, for which specific generator details cannot be provided)
 wecc_states = ['WA','OR','CA','AZ','NV','NM','UT','ID','MT','WY','CO','TX']
 accepted_status_codes = ['OP','SB','CO','SC','OA','OZ','TS','L','T','U','V']
+# from: https://www.seia.org/sites/default/files/EIA-860.pdf
+# generator status codes:
+# OP = operating, in service, SB = standby/backup, CO = New unit under construction, SC =
+# Cold Standby (Reserve); deactivated. OA = Out of service, was not used for some or all
+# of the reporting period but was
+# either returned to service on December 31 or will be returned to service in the next calendar year,
+# OZ = Operated during the ozone season,
+# TS = construction complete but not yet in commercial operation,
+# L=regulatory approvals pending, not under construction but site prep underway
+# T= regulatory approvals received, not under construction but site prep underway,
+# U = Under construction, less than or equal to 50 percent complete,
+# V = Under construction, more than 50 percent complete
 coal_codes = ['ANT','BIT','LIG','SGC','SUB','WC','RC']
+# from: https://www.seia.org/sites/default/files/EIA-860.pdf
+# coal status codes:
+# ANT = Anthracite Coal, BIT = Bituminous Coal, LIG = Lignite Coal, SGC =
+# Coal-Derived Synthesis Gas, SUB = Subbituminous Coal, WC = Waste/Other Coal, RC =Recirculating cooling
 gen_relevant_data = ['Plant Code', 'Plant Name', 'Status', 'Nameplate Capacity (MW)',
                     'Prime Mover', 'Energy Source', 'Energy Source 2',
                     'Energy Source 3', 'County', 'State', 'Nerc Region',
                     'Operating Year', 'Planned Retirement Year',
                     'Generator Id', 'Unit Code', 'Operational Status']
+#Nerc region and operational status are in the "Plant file, the rest are in the "Generator" file
 gen_data_to_be_summed = ['Nameplate Capacity (MW)']
 gen_aggregation_lists = [
                             ['Plant Code','Unit Code'],
                             ['Plant Code', 'Prime Mover', 'Energy Source',
                             'Operating Year']
                         ]
+#multiple generator units (in Generator file) may be at the same plant location and are aggregated by plant code
 gen_relevant_data_for_last_year = ['Time From Cold Shutdown To Full Load',
                         'Latitude','Longitude','Balancing Authority Name',
                         'Grid Voltage (kV)', 'Carbon Capture Technology', 'Cogen']
@@ -79,13 +107,17 @@ def uniformize_names(df):
         'Primemover':'Prime Mover',
         'Current Year':'Operating Year',
         'Utilcode':'Utility Id',
+        'Utility ID': 'Utility Id',
         'Nerc':'Nerc Region',
         'Insvyear':'Operating Year',
         'Retireyear':'Planned Retirement Year',
         'Cntyname':'County',
         'Proposed Nameplate':'Nameplate Capacity (MW)',
         'Proposed Status':'Status',
-        'Eia Plant Code':'Plant Code'
+        'Eia Plant Code':'Plant Code',
+        'Entity ID' : 'Entity Id',
+        'Prime Mover Code':'Prime Mover',
+        'Plant State':'State',
         }, inplace=True)
     return df
 
@@ -99,18 +131,28 @@ def main():
         for f in os.listdir(outputs_directory):
             os.remove(os.path.join(outputs_directory,f))
 
+    #download and process annual EIA860 data (generator and plant project information)
     zip_file_list = scrape_eia860()
     unzip(zip_file_list)
     eia860_directory_list = [os.path.splitext(f)[0] for f in zip_file_list]
     for eia860_annual_filing in eia860_directory_list:
         parse_eia860_data(eia860_annual_filing)
 
+    #download and process EIA923 data (monthly generation and heat rate information)
     zip_file_list = scrape_eia923()
     unzip(zip_file_list)
     eia923_directory_list = [os.path.splitext(f)[0] for f in zip_file_list]
     for eia923_annual_filing in eia923_directory_list:
-        parse_eia923_data(eia923_annual_filing)
+       parse_eia923_data(eia923_annual_filing)
 
+    #download and process latest cumulative generator retirement data from monthly EIA860 data and
+    # reconcile with latest annual EIA860 (as of end_year)
+    zip_file_list = scrape_eia860_monthly()
+    unzip(zip_file_list)
+    eia860_annual_input_dir_name = 'eia860' + str(end_year)
+    eia860_annual_input_dir = os.path.join(unzip_directory,eia860_annual_input_dir_name)
+    eia860_monthly_input_dir = unzip_directory
+    parse_most_recent_eia860M_data(eia860_annual_input_dir, eia860_monthly_input_dir)
 
 def scrape_eia860():
     """
@@ -127,8 +169,13 @@ def scrape_eia860():
         if REUSE_PRIOR_DOWNLOADS and os.path.isfile(local_path):
             print "Skipping " + filename + " because it was already downloaded."
             continue
-        print "Downloading " + local_path
-        url = 'http://www.eia.gov/electricity/data/eia860/xls/' + filename
+        if '2018' in filename: #this needs to be changed to the most recent year data is available if the code is updated later
+            base_path = 'http://www.eia.gov/electricity/data/eia860/xls/{}'
+        else: #years prior to 2018 have "archive" in the path name
+            base_path = 'http://www.eia.gov/electricity/data/eia860/archive/xls/{}'
+
+        url = base_path.format(filename)
+        print "Downloading {} from {}".format(local_path, url)
         meta_data = download_file(url, local_path)
         log_dat.append(meta_data)
 
@@ -140,9 +187,48 @@ def scrape_eia860():
         if write_log_header:
             logwriter.writerow(download_metadata_fields)
         logwriter.writerows(log_dat)
-    
+
     return [os.path.join(unzip_directory, f) for f in file_list]
 
+def scrape_eia860_monthly():
+    """
+    New added function that downloads the most recent preliminary monthly EIA-860M form for the most recent end_year+2 because
+    it contains the cumulative list of retired generators. (The most recent monthly EIA-860M form tends to be 2 years more recent
+    than the end_year of the annual EIA-860 forms.) The annual EIA-860 retired list only includes those retired generators which
+    were reported in the most current data cycle and is not a comprehensive list.  Starting with March 2017 data,
+    Preliminary Monthly Electric Generator Inventory table (https://www.eia.gov/electricity/data/eia860m/) includes
+    a comprehensive list of generators which retired since 2002. The list can be found on the 'Retired' tab of the data file.
+    """
+    #File path of most recent monthly 860 form
+    #https://www.eia.gov/electricity/data/eia860m/xls/may_generator2020.xlsx
+
+    if not os.path.exists(unzip_directory):
+        os.makedirs(unzip_directory)
+    log_dat = []
+    file_list = ['{}_generator{}.xlsx'.format(end_month, end_year+2)]
+    for filename in file_list:
+        local_path = os.path.join(unzip_directory, filename)
+        if REUSE_PRIOR_DOWNLOADS and os.path.isfile(local_path):
+            print "Skipping " + filename + " because it was already downloaded."
+            continue
+        else:
+            base_path = 'https://www.eia.gov/electricity/data/eia860m/xls/{}'
+
+        url = base_path.format(filename)
+        print "Downloading {} from {}".format(local_path, url)
+        meta_data = download_file(url, local_path)
+        log_dat.append(meta_data)
+
+    # Only write the log file header if we are starting a new log
+    write_log_header = not os.path.isfile(download_log_path)
+    with open(download_log_path, 'ab') as logfile:
+        logwriter = csv.writer(logfile, delimiter='\t',
+                               quotechar="'", quoting=csv.QUOTE_MINIMAL)
+        if write_log_header:
+            logwriter.writerow(download_metadata_fields)
+        logwriter.writerows(log_dat)
+
+    return [os.path.join(unzip_directory, f) for f in file_list]
 
 def scrape_eia923():
     """
@@ -162,7 +248,11 @@ def scrape_eia923():
             print "Skipping " + filename + " because it was already downloaded."
             continue
         print "Downloading " + local_path
-        url = 'https://www.eia.gov/electricity/data/eia923/xls/' + filename
+        if '2019' in filename:
+            base_path = 'https://www.eia.gov/electricity/data/eia923/xls/{}'
+        else: #years prior to 2018 have "archive" in the path name
+            base_path = 'https://www.eia.gov/electricity/data/eia923/archive/xls/{}'
+        url = base_path.format(filename)
         meta_data = download_file(url, local_path)
         log_dat.append(meta_data)
 
@@ -174,7 +264,7 @@ def scrape_eia923():
         if write_log_header:
             logwriter.writerow(download_metadata_fields)
         logwriter.writerows(log_dat)
-    
+
     return [os.path.join(unzip_directory, f) for f in file_list]
 
 
@@ -184,13 +274,13 @@ def parse_eia860_data(directory):
 
     First, data for existing and proposed plants and units are merged together.
     Some information is only specified per plant and not unit (i.e. NERC region).
-    
+
     Proposed units are filtered according to status, as defined in accepted_status_codes.
     For now, all status up to units with regulatory approvals pending are accepted
     as certain. If a unit has not initiated regulatory approval processes, then
     it is filtered out.
 
-    Gas and steam turbines of combined cycle plants are considered indistinct,
+    Gas (CT) and steam (CA) turbines of combined cycle plants (CC) are considered indistinct,
     treated as 'CC' technologies.
 
     Generator data is aggregated according to the lists defined in
@@ -200,7 +290,7 @@ def parse_eia860_data(directory):
     same combined cycle (though there are some other cases). Secondly, units are
     aggregated by plant, technology, energy source and vintage. Both aggregations
     reduce the generator set without any loss of precision if no integer unit
-    commitment will be performed. 
+    commitment will be performed.
 
     """
 
@@ -214,13 +304,13 @@ def parse_eia860_data(directory):
     pickle_path_plants = os.path.join(pickle_directory,'eia860_{}_plants.pickle'.format(year))
     pickle_path_existing_generators = os.path.join(pickle_directory,'eia860_{}_existing.pickle'.format(year))
     pickle_path_proposed_generators = os.path.join(pickle_directory,'eia860_{}_proposed.pickle'.format(year))
-    
+
     if not os.path.exists(pickle_path_plants) \
         or not os.path.exists(pickle_path_existing_generators) \
             or not os.path.exists(pickle_path_proposed_generators) \
                 or REWRITE_PICKLES:
         print "Pickle files have to be written for this EIA860 form. Creating..."
-        # Different number of blank rows depending on year
+        # Different number of blank header rows depending on year
         if year <= 2010:
             rows_to_skip = 0
         else:
@@ -228,6 +318,7 @@ def parse_eia860_data(directory):
 
         for f in os.listdir(directory):
             path = os.path.join(directory, f)
+            f = f.lower()
             # Use a simple for loop, since for years previous to 2008, there are
             # multiple ocurrences of "GenY" in files. Haven't found a clever way
             # to do a pattern search with Glob that excludes unwanted files.
@@ -237,26 +328,37 @@ def parse_eia860_data(directory):
             # From 2009 onwards, look for files with "Plant" and "Generator"
             # in their name.
             # Avoid trying to read a temporal file if any Excel workbook is open
-            if 'Plant' in f and '~' not in f:
-                plants = uniformize_names(
-                    pd.read_excel(path, sheetname=0, skiprows=rows_to_skip))
-            if 'Generator' in f and '~' not in f:
-                existing_generators = uniformize_names(
-                    pd.read_excel(path, sheetname=0, skiprows=rows_to_skip))
+            if 'plant' in f and '~' not in f:
+                #different file type (.dbf) from 2003 backwards
+                if f.endswith('.dbf'):
+                    dataframe = Dbf5(path).to_dataframe()
+                else:
+                    dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                plants = uniformize_names(dataframe)
+            if 'generator' in f and '~' not in f:
+                dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                existing_generators = uniformize_names(dataframe)
                 existing_generators['Operational Status'] = 'Operable'
-                proposed_generators = uniformize_names(
-                    pd.read_excel(path, sheetname=1, skiprows=rows_to_skip))
+                dataframe = pd.read_excel(path, sheet_name=1, skiprows=rows_to_skip)
+                proposed_generators = uniformize_names(dataframe)
                 proposed_generators['Operational Status'] = 'Proposed'
-            # Different names from 2008 backwards
-            if f.startswith('PRGenY'):
-                proposed_generators = uniformize_names(
-                    pd.read_excel(path, sheetname=0, skiprows=rows_to_skip))
+            # Different names from 2008 backwards (proposed generators are in separate file rather
+            # than different sheet in same file)
+            if f.startswith('prgeny'):
+                if f.endswith('.dbf'):
+                    dataframe = Dbf5(path).to_dataframe()
+                else:
+                    dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                proposed_generators = uniformize_names(dataframe) #is this case sensitive?
                 proposed_generators['Operational Status'] = 'Proposed'
-            if f.startswith('GenY'):
-                existing_generators = uniformize_names(
-                    pd.read_excel(path, sheetname=0, skiprows=rows_to_skip))
+            if f.startswith('geny'):
+                if f.endswith('.dbf'):
+                    dataframe = Dbf5(path).to_dataframe()
+                else:
+                    dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                existing_generators = uniformize_names(dataframe)
                 existing_generators['Operational Status'] = 'Operable'
-        
+
         plants.to_pickle(pickle_path_plants)
         existing_generators.to_pickle(pickle_path_existing_generators)
         proposed_generators.to_pickle(pickle_path_proposed_generators)
@@ -265,7 +367,7 @@ def parse_eia860_data(directory):
         plants = pd.read_pickle(pickle_path_plants)
         existing_generators = pd.read_pickle(pickle_path_existing_generators)
         proposed_generators = pd.read_pickle(pickle_path_proposed_generators)
-
+    #join the existing generator project and existing plant level data, and append list of proposed generators
     generators = pd.merge(existing_generators, plants,
         on=['Utility Id','Plant Code', 'Plant Name','State'],
         suffixes=('_units', ''))
@@ -273,7 +375,7 @@ def parse_eia860_data(directory):
     print "Read in data for {} existing and {} proposed generation units in "\
         "the US.".format(len(existing_generators), len(proposed_generators))
 
-    # Filter projects according to status
+    # Filter projects according to status (operable or proposed and far along in regulatory and/or construction process)
     generators = generators.loc[generators['Status'].isin(accepted_status_codes)]
     print "Filtered to {} existing and {} proposed generation units by removing inactive "\
         "and planned projects not yet started.".format(
@@ -281,15 +383,17 @@ def parse_eia860_data(directory):
             len(generators[generators['Operational Status']=='Proposed']))
 
     # Replace chars in numeric columns with null values
-    # Most appropriate way would be to replace value with another column
     for col in gen_data_to_be_summed:
         generators[col].replace(' ', float('nan'), inplace=True)
         generators[col].replace('.', float('nan'), inplace=True)
 
-    # Manually set Prime Mover of combined cycle plants before aggregation
+    # Manually set Prime Mover of combined cycle plants before aggregation because CA, CT, and CS all
+    # describe different components of a combined cycle (CC) plant
     generators.loc[generators['Prime Mover'].isin(['CA','CT','CS']),'Prime Mover'] = 'CC'
 
-    # Aggregate according to user criteria
+    # Aggregate according to user criteria (default setting is to sum nameplate capacity across all generator units and take
+    # the maximum of all other parameters, grouping by generator plant)
+    # last year of data has some additional columns aggregated
     for agg_list in gen_aggregation_lists:
         # Assign unique values to empty cells in columns that will be aggregated upon
         for col in agg_list:
@@ -314,9 +418,9 @@ def parse_eia860_data(directory):
             "through {}.".format(len(generators[generators['Operational Status']=='Operable']),
             len(generators[generators['Operational Status']=='Proposed']), agg_list)
 
-    # Drop columns that are no longer needed
+    # Drop columns that are no longer needed (aggegation is across generator units in a plant)
     generators = generators.drop(['Unit Code','Generator Id'], axis=1)
-    # Add EIA prefix to be explicit about code origin
+    # Add EIA prefix to be explicit about plant code number origin
     generators = generators.rename(columns={'Plant Code':'EIA Plant Code'})
 
     fname = 'generation_projects_{}.tab'.format(year)
@@ -324,6 +428,186 @@ def parse_eia860_data(directory):
         generators.to_csv(f, sep='\t', encoding='utf-8', index=False)
     print "Saved data to {} file.\n".format(fname)
 
+def parse_most_recent_eia860M_data(eia860_annual_input_dir, eia860_monthly_input_dir):
+    """
+
+    The cumulative list of retired generators (since 2002) is part of the EIA860 Monthly form, which
+    is available for more recent months (typically 3 monthls behind the current month) than the annual
+    EIA860 form (typically 2 years behind the current year). Therefore, this function compares the
+    cumulative list of retired generators from the most recent EIA860 Monthly form
+    with the list of propposed and existing generators from most reccent EIA860 annual
+    form to make sure that the annual data doesn't include any generators that have since been retired.
+    This comparison is done by generator ID, before the data is later aggregated to the plant level,
+    because some generator units may still be operational in the same plant where some have been retired.
+
+    Similar to the annual EIA860 parsing function, first, data for existing and proposed plants and
+    units are merged together from the annual EIA860 form.
+
+    Proposed units are filtered according to status, as defined in accepted_status_codes.
+    For now, all status up to units with regulatory approvals pending are accepted
+    as certain. If a unit has not initiated regulatory approval processes, then
+    it is filtered out.
+
+    Gas (CT) and steam (CA) turbines of combined cycle plants (CC) are considered indistinct,
+    treated as 'CC' technologies.
+
+    Then, the EIA860 Monthly Form data is processesd to get cumulative list of retired generators by
+    Generator ID (before aggregating up to Plant level because some generators may have been
+    retired in the same plant where some generators remain operational). As with the annual 860 form,
+    the Gas and steam turbines of CC plants are similarly treated as CC technologies.
+
+    Then the annual 860 existing and proposed generator list is joined in an inner join with the retired
+    monthly 860 form by generator ID.
+
+    The data is filtered for WECC states and any matches in the join are output as a CSV for analysis.
+
+    The data on retired generator units in WECC states is also aggregated up to the plant level and output as a CSV.
+
+    """
+
+    #only run this function for the last year of the data, which is 2018 as of this writing
+    year = int(2018)
+
+    if year == end_year:
+
+        print "============================="
+        print "Processing data for year {}.".format(year)
+
+        rows_to_skip = 1
+
+        for f in os.listdir(eia860_annual_input_dir):
+            path = os.path.join(eia860_annual_input_dir, f)
+            f = f.lower()
+
+            # look for files with "Plant" and "Generator" in their name.
+
+            if 'plant' in f and '~' not in f:
+                dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                plants = uniformize_names(dataframe)
+            if 'generator' in f and '~' not in f:
+                dataframe = pd.read_excel(path, sheet_name=0, skiprows=rows_to_skip)
+                existing_generators = uniformize_names(dataframe)
+                try:
+                    existing_generators = existing_generators.astype({'Utility Id': 'int64'})
+                except ValueError:
+                    # The data frame may have an extra information row. If so, drop it.
+                    existing_generators.drop(existing_generators.tail(1).index,inplace=True)
+                    existing_generators = existing_generators.astype({'Utility Id': 'int64'})
+                existing_generators['Operational Status'] = 'Operable'
+
+                dataframe = pd.read_excel(path, sheet_name=1, skiprows=rows_to_skip)
+                proposed_generators = uniformize_names(dataframe)
+                proposed_generators['Operational Status'] = 'Proposed'
+        #join the existing generator and existing plant level data, and append list of proposed generators to dataframe
+        generators = pd.merge(existing_generators, plants,
+            on=['Utility Id','Plant Code', 'Plant Name','State'],
+            suffixes=('_units', ''))
+        generators = generators.append(proposed_generators)
+        print "Read in data for {} existing and {} proposed generation units in "\
+            "the US.".format(len(existing_generators), len(proposed_generators))
+
+        # Filter projects according to status (operable or proposed and far along in regulatory and/or construction process)
+        generators = generators.loc[generators['Status'].isin(accepted_status_codes)]
+        print "Filtered to {} existing and {} proposed generation units by removing inactive "\
+            "and planned projects not yet started.".format(
+                len(generators[generators['Operational Status']=='Operable']),
+                len(generators[generators['Operational Status']=='Proposed']))
+
+        # Manually set Prime Mover of combined cycle plants before aggregation because CA, CT, and CS all
+        # describe different components of a combined cycle (CC) plant
+        generators.loc[generators['Prime Mover'].isin(['CA','CT','CS']),'Prime Mover'] = 'CC'
+
+        #reading in list of retired plants from monthly EIA 860 form which is 2 years ahead of annual EIA 860 form
+        print "============================="
+        print "Processing cumulative retired plant data as of {} {}.".format(end_month, end_year+2)
+
+        for f in os.listdir(eia860_monthly_input_dir):
+
+            path = os.path.join(eia860_monthly_input_dir, f)
+            f = f.lower()
+            rows_to_skip = 1
+
+            # Look for files with End month and "Generator" in their name. Note that monthly data is 2 years ahead of annual data, hence you need to add 2 below
+            if 'generator' in f and str(end_month) in f and str(year+2) in f and f.endswith('xlsx'):
+
+                dataframe = pd.read_excel(path, sheet_name=2, skiprows=rows_to_skip)
+
+                retired_generators = uniformize_names(dataframe)
+
+        # Manually set Prime Mover of combined cycle plants before aggregation because CA, CT, and CS all
+        # describe different components of a combined cycle (CC) plant
+        retired_generators.loc[retired_generators['Prime Mover'].isin(['CA','CT','CS']),'Prime Mover'] = 'CC'
+
+        #join the existing and proposed generator list from most recent annual 860 list with the most recent monthly 860 retired
+        # generator list by generator
+
+        retired_generators_in_project_list = pd.merge(generators[['Cogen','County',
+        'Energy Source','Generator Id','Nameplate Capacity (MW)','Nerc Region',
+        'Operating Year','Operational Status','Plant Code','Plant Name',
+        'Prime Mover','Regulatory Status','State','Technology','Unit Code','Utility Id','Utility Name']],
+        retired_generators[['Entity Id','Plant Code','Generator Id','State','Prime Mover','Nameplate Capacity (MW)',
+        'Retirement Month','Retirement Year','Operating Year']],
+            left_on=['Utility Id','Plant Code','Generator Id','State','Prime Mover','Operating Year','Nameplate Capacity (MW)'],
+            right_on = ['Entity Id','Plant Code','Generator Id','State','Prime Mover','Operating Year','Nameplate Capacity (MW)'],
+            how = 'inner')
+
+        print "There are {} retired generation units as of {} {} that are still in the most recent {} annual generation project list "\
+            "in the US.".format(len(retired_generators_in_project_list), end_month, end_year+2, end_year)
+
+        retired_generators_in_project_list = retired_generators_in_project_list.rename(columns={'Plant Code':'EIA Plant Code'})
+
+        #filtering out just generators in WECC states
+        wecc_filter = retired_generators_in_project_list['State'].isin(wecc_states)
+        wecc_retired_generators_in_project_list = retired_generators_in_project_list[wecc_filter]
+
+        print "There are {} retired generation units as of {} {} that are still in the most recent {} annual generation project list "\
+            "in the WECC states.".format(len(wecc_retired_generators_in_project_list), end_month, end_year+2, end_year)
+
+        #Only keep subset of columns
+        wecc_retired_generators_in_project_list_condensed = wecc_retired_generators_in_project_list[['EIA Plant Code', 'Plant Name', 'Nameplate Capacity (MW)', 'Operating Year',
+        'Prime Mover', 'Energy Source', 'State','County','Retirement Year','Generator Id', 'Unit Code', 'Regulatory Status']]
+
+        #output to CSV list of retired (or planned retired) WECC generator units still in generator project list
+        fname = 'retired_WECC_generation_units_still_in_generator_projects_{}.tab'.format(end_year)
+        with open(os.path.join(outputs_directory, fname),'w') as f:
+            wecc_retired_generators_in_project_list_condensed.to_csv(f, sep='\t', encoding='utf-8', index=False)
+        print "Saved data to {} file.\n".format(fname)
+
+        wecc_retired_generators_in_project_list = wecc_retired_generators_in_project_list.rename(columns={'EIA Plant Code':'Plant Code', 'Operational Status':'Status'})
+
+        gen_relevant_data2 = ['Plant Code', 'Plant Name', 'Nameplate Capacity (MW)', 'Operating Year','Prime Mover', 'Energy Source', 'State','County',
+        'Retirement Year','Generator Id', 'Unit Code', 'Regulatory Status']
+
+        # Aggregate retired plants according to user criteria (same as operating plants)
+        agg_list = ['Plant Code', 'Prime Mover', 'Energy Source','Operating Year']
+        # Assign unique values to empty cells in columns that will be aggregated upon
+        for col in agg_list:
+            if wecc_retired_generators_in_project_list[col].dtype == np.float64:
+                wecc_retired_generators_in_project_list[col].fillna(
+                    {i:10000000+i for i in wecc_retired_generators_in_project_list.index}, inplace=True)
+            else:
+                wecc_retired_generators_in_project_list[col].fillna(
+                    {i:'None'+str(i) for i in wecc_retired_generators_in_project_list.index}, inplace=True)
+        wecc_retired_gb = wecc_retired_generators_in_project_list.groupby(agg_list)
+
+        # Nameplate capacity will be summed and all others will get the 'max' value
+        # Columns are reordered after aggregation for easier inspection
+        wecc_retired_agg = wecc_retired_gb.agg({datum:('max' if datum not in gen_data_to_be_summed else sum)
+                            for datum in gen_relevant_data2}).loc[:,gen_relevant_data2]
+        wecc_retired_agg.reset_index(drop=True, inplace=True)
+        print "Aggregated to {} retired generation units by aggregating "\
+            "through {}.".format(len(wecc_retired_agg[wecc_retired_agg['Retirement Year']>=2017]), agg_list)
+
+        # Drop columns that are no longer needed
+        wecc_retired_agg = wecc_retired_agg.drop(['Unit Code','Generator Id','Energy Source'], axis=1)
+
+        wecc_retired_agg = wecc_retired_agg.rename(columns={'Plant Code':'EIA Plant Code'})
+
+        #export aggregated list of retired plants still in dataset into csv for analyis
+        fname = 'retired_WECC_aggregated_generation_projects_{}.tab'.format(year)
+        with open(os.path.join(outputs_directory, fname),'w') as f:
+            wecc_retired_agg.to_csv(f, sep='\t', encoding='utf-8', index=False)
+            print "Saved data to {} file.\n".format(fname)
 
 def parse_eia923_data(directory):
     """
@@ -391,7 +675,7 @@ def parse_eia923_data(directory):
         Plants that use multiple fuels (generate more than 5% of the time with
         their secondary fuel) are printed to a separate file and a summary is
         printed to console.
-        
+
 
 
     """
@@ -416,7 +700,7 @@ def parse_eia923_data(directory):
         else:
             rows_to_skip = 7
         generation = uniformize_names(pd.read_excel(largest_file,
-            sheetname='Page 1 Generation and Fuel Data', skiprows=rows_to_skip))
+            sheet_name='Page 1 Generation and Fuel Data', skiprows=rows_to_skip))
         generation.to_pickle(pickle_path)
     else:
         print "Pickle file exists for this EIA923. Reading..."
@@ -431,13 +715,14 @@ def parse_eia923_data(directory):
            "and plants in the US.").format(len(generation))
 
     # Replace characters with proper nan values
-    numeric_columns = [col for col in generation.columns if 
+    numeric_columns = [col for col in generation.columns if
         re.compile('(?i)elec[_\s]mmbtu').match(col) or re.compile('(?i)netgen').match(col)]
     for col in numeric_columns:
         generation[col].replace(' ', float('nan'), inplace=True)
         generation[col].replace('.', float('nan'), inplace=True)
 
     # Aggregated generation of plants. First assign CC as prime mover for combined cycles.
+    # Flag hydropower generators with WAT as prime mover, and fuel based gneration
     generation.loc[generation['Prime Mover'].isin(['CA','CT','CS']),'Prime Mover']='CC'
     gb = generation.groupby(['Plant Code','Prime Mover','Energy Source'])
     generation = gb.agg({datum:('max' if datum not in numeric_columns else sum)
@@ -465,11 +750,11 @@ def parse_eia923_data(directory):
     hydro_gen_projects = generation_projects[
         (generation_projects['Operational Status']=='Operable') &
         (generation_projects['Energy Source']=='WAT')].rename(
-            columns={'EIA Plant Code':'Plant Code'})
+            columns={'EIA Plant Code':'Plant Code'}).reset_index(drop=True)
     fuel_based_gen_projects = generation_projects[
         (generation_projects['Operational Status']=='Operable') &
         (generation_projects['Prime Mover'].isin(fuel_prime_movers))].rename(
-            columns={'EIA Plant Code':'Plant Code'})
+            columns={'EIA Plant Code':'Plant Code'}).reset_index(drop=True)
     print "Aggregated plant data into {} records".format(len(generation_projects))
     print "\tHydro projects:{}".format(len(hydro_gen_projects))
     print "\tFuel based projects:{}".format(len(fuel_based_gen_projects))
@@ -484,8 +769,10 @@ def parse_eia923_data(directory):
         with summaries.
         """
         # Projects with plant data, but no production data
+        #projects_missing_production = np.where(projects['Plant Code'].isin(production['Plant Code']), null, projects)
+
         filter = projects['Plant Code'].isin(production['Plant Code'])
-        projects_missing_production = projects[~filter]
+        projects_missing_production = projects[~filter].reset_index(drop=True)
         missing_MW = projects_missing_production['Nameplate Capacity (MW)'].sum()
         total_MW = projects['Nameplate Capacity (MW)'].sum()
         print ("{} of {} {} generation projects in the EIA860 plant form "
@@ -499,31 +786,32 @@ def parse_eia923_data(directory):
                 gen_type,
                 missing_MW, total_MW,
               )
+        #summary.index.name = None
         summary = projects_missing_production.groupby(
                                             ['Plant Code', 'Plant Name']).sum()
         summary['Net Generation (Megawatthours)'] = float('NaN')
-        summary.to_csv(log_path, 
+        summary.to_csv(log_path,
             columns=['Nameplate Capacity (MW)', 'Net Generation (Megawatthours)'])
 
         # Projects with generation data, but no plant data
         filter = production['Plant Code'].isin(projects['Plant Code'])
-        production_missing_project = production[~filter]
+        production_missing_project = production[~filter].reset_index(drop=True)
         missing_MWh = production_missing_project['Net Generation (Megawatthours)'].sum()
         total_MWh = production['Net Generation (Megawatthours)'].sum()
         print ("{} of {} {} generation projects in the EIA923 generation form "
                "are not in the EIA860 plant form: {:.4f}% "
                "total annual {} production ({:.0f} of {:.0f} MWh)."
               ).format(
-                len(production_missing_project), len(production), 
+                len(production_missing_project), len(production),
                 gen_type,
                 100 * (missing_MWh / total_MWh),
                 gen_type,
-                missing_MWh, total_MWh, 
+                missing_MWh, total_MWh,
               )
         summary = production_missing_project.groupby(
                                             ['Plant Code', 'Plant Name']).sum()
         summary['Nameplate Capacity (MW)'] = float('NaN')
-        summary.to_csv(log_path, mode='a', header=False, 
+        summary.to_csv(log_path, mode='a', header=False,
             columns=['Nameplate Capacity (MW)', 'Net Generation (Megawatthours)'])
         print ("Summarized {} plants with missing data to {}."
               ).format(gen_type, log_path)
@@ -536,7 +824,7 @@ def parse_eia923_data(directory):
                                       'hydro', log_path)
     log_path = os.path.join(outputs_directory,
         'incomplete_data_thermal_{}.csv'.format(year))
-    check_overlap_proj_and_production(fuel_based_gen_projects, fuel_based_generation, 
+    check_overlap_proj_and_production(fuel_based_gen_projects, fuel_based_generation,
                                       'thermal', log_path)
 
     # Recover original column order
@@ -556,14 +844,16 @@ def parse_eia923_data(directory):
 
     ###############
     # WIDE format
+    #getting both net generation and electric generation "consumed" to calculate gross hydropower generation
+    #calculating the monthly capacity factor for hydropower = monthly generation (MWh)/(hours in month * MW capacity)
     hydro_outputs=pd.concat([
         hydro_generation[['Year','Plant Code','Plant Name','Prime Mover']],
         hydro_generation.filter(regex=r'(?i)netgen'),
         hydro_generation.filter(regex=r'(?i)elec quantity')
-        ], axis=1)
+        ], axis=1).reset_index(drop=True)
     hydro_outputs=pd.merge(hydro_outputs, hydro_gen_projects[['Plant Code',
         'Prime Mover', 'Nameplate Capacity (MW)', 'County', 'State']],
-        on=['Plant Code','Prime Mover'], suffixes=('',''))
+        on=['Plant Code','Prime Mover'], suffixes=('','')).reset_index(drop=True)
     for month in range(1,13):
         hydro_outputs.rename(
             columns={hydro_outputs.columns[3+month]:
@@ -574,9 +864,9 @@ def parse_eia923_data(directory):
                 'Electricity Consumed (MWh) Month {}'.format(month)},
             inplace=True)
         hydro_outputs.loc[:,'Net Electricity Generation (MWh) Month {}'.format(month)] += \
-            hydro_outputs.loc[:,'Electricity Consumed (MWh) Month {}'.format(month)]
+            hydro_outputs.loc[:,'Electricity Consumed (MWh) Month {}'.format(month)].replace(to_replace='.', value=0)
         hydro_outputs.loc[:,'Capacity Factor Month {}'.format(month)] = \
-            hydro_outputs.loc[:,'Net Electricity Generation (MWh) Month {}'.format(month)].div(
+            hydro_outputs.loc[:,'Net Electricity Generation (MWh) Month {}'.format(month)].replace(to_replace='.', value=0).div(
             monthrange(int(year),month)[1]*24*hydro_outputs['Nameplate Capacity (MW)'])
 
     append_historic_output_to_csv(
@@ -628,7 +918,7 @@ def parse_eia923_data(directory):
             ['Plant Code','Plant Name','Prime Mover','Energy Source','Year']],
             fuel_based_generation.filter(regex=r'(?i)elec[_\s]mmbtu'),
             fuel_based_generation.filter(regex=r'(?i)netgen')
-        ], axis=1)
+        ], axis=1).reset_index(drop=True)
 
     # Aggregate consumption/generation of/by different types of coal in a same plant
     if AGGREGATE_COAL:
@@ -656,7 +946,7 @@ def parse_eia923_data(directory):
     total_fuel_consumption = pd.concat([
             fuel_based_generation[['Plant Code','Prime Mover']],
             fuel_based_generation.filter(regex=r'(?i)elec[_\s]mmbtu')
-            ], axis=1)
+            ], axis=1).reset_index(drop=True)
     total_fuel_consumption.rename(columns={
         total_fuel_consumption.columns[1+m]:
         'Fraction of Total Fuel Consumption Month {}'.format(m)
@@ -687,11 +977,11 @@ def parse_eia923_data(directory):
         heat_rate_outputs.loc[:,'Fraction of Total Fuel Consumption Month {}'.format(month)] = \
             heat_rate_outputs.loc[:,'Heat Rate Month {}'.format(month)].div(
             heat_rate_outputs.loc[:,'Fraction of Total Fuel Consumption Month {}'.format(month)])
-        # Heat rates
+        # Monthly heat rates
         heat_rate_outputs.loc[:,'Heat Rate Month {}'.format(month)] = \
             heat_rate_outputs.loc[:,'Heat Rate Month {}'.format(month)].div(
                 heat_rate_outputs.loc[:,'Net Electricity Generation (MWh) Month {}'.format(month)])
-        # Capacity factors
+        # Monthly capacity factors
         heat_rate_outputs['Capacity Factor Month {}'.format(month)] = \
             heat_rate_outputs.loc[:,'Net Electricity Generation (MWh) Month {}'.format(month)].div(
                 monthrange(int(year),month)[1]*24*heat_rate_outputs['Nameplate Capacity (MW)'])
@@ -706,8 +996,7 @@ def parse_eia923_data(directory):
         " them to negative_heat_rate_outputs.tab".format(
         len(negative_heat_rate_outputs)))
 
-    # Get the second best heat rate in a separate column
-    heat_rate_outputs.reset_index(inplace=True)
+    # Get the second best heat rate in a separate column (best heat rate may be too good to be true or data error)
     heat_rate_outputs.loc[:,'Best Heat Rate'] = pd.DataFrame(
         np.sort(heat_rate_outputs.replace([0,float('inf')],float('nan'))[
             heat_rate_outputs>0].filter(regex=r'Heat Rate'))).iloc[:,1]
@@ -774,8 +1063,12 @@ def parse_eia923_data(directory):
     # Don't identify as multi-fuel plants that use different fuels in different units
     indices_to_drop = []
     for row in multi_fuel_heat_rate_outputs.iterrows():
-        if len(fuel_based_gen_projects.loc[row[1]['Plant Code'],row[1]['Prime Mover']]) > 1:
-            indices_to_drop.append(int(row[0]))
+        try:
+            if len(fuel_based_gen_projects.loc[row[1]['Plant Code'],row[1]['Prime Mover']]) > 1:
+                indices_to_drop.append(int(row[0]))
+        except KeyError:
+            # Plant Code and Prime Mover combo don't exist, so no need to drop an index
+            pass
     multi_fuel_heat_rate_outputs = multi_fuel_heat_rate_outputs.drop(indices_to_drop)
 
     append_historic_output_to_csv(

--- a/validate_variable_capacity_factors.sql
+++ b/validate_variable_capacity_factors.sql
@@ -1,0 +1,23 @@
+-- this query is run to double check that the hours of 0 variable capacity factors
+-- do not occur in the middle of the day, and only occur in the middle of the night or
+-- during 'shoulder' hours for solar generators (difficult to assess with wind)
+-- since the data is in utc, the output of the query is copied into a CSV and converted
+-- to Pacific time for easier inspection.
+
+-- run on db command line: cat validate_variable_capacity_factors.sql | psql -d switch_wecc > analysis
+
+SELECT COUNT(*),
+extract(year from a.timestamp_utc) as utc_year,
+extract(hour from a.timestamp_utc) as utc_hour, 
+MAX(a.timestamp_utc) as max_utc_hour, 
+MIN(a.timestamp_utc) as min_utc_hour
+FROM variable_capacity_factors a
+JOIN generation_plant_scenario_member b ON a.generation_plant_id = b.generation_plant_id
+JOIN generation_plant c on c.generation_plant_id = a.generation_plant_id
+WHERE b.generation_plant_scenario_id = 19
+AND c.energy_source = 'Solar'
+AND c.gen_tech = 'PV'
+AND a.capacity_factor = 0
+GROUP BY utc_year, utc_hour
+ORDER BY utc_year, utc_hour;
+


### PR DESCRIPTION
Changes detailed below...

Scrape.py:
- Update the date range to scrape the EIA 860 and EIA 923 form data for 2004 through 2018. This updates the latest year of data from 2015 to 2018, and also extends the start of the period to 2004 to have a longer record on which to average heat rates and hydropower capacity factor.
- Added a function to scrape the most recent Monthly EIA 860M form. This creates a dataset of generators in the WECC states that are in the latest list of existing generators from the EIA 860 annual dataset (as of 2018) but have been retired as of May 2020 (the most recently available monthly EIA 860M form has cumulative retirements up to May 2020).

Database_interface.py:
- Added an option to run the script on backup tables during testing, before running on the original db tables. The idea is to 1. make backup tables as copies of the original tables, 2. test the code on these backup tables until satisfied. 3. recreate the backup tables as copies of the original tables, 4. rerun the script on the original tables.
- All the queries in the code now have a "prefix" option that allows for running on backup tables that have a prefix in the name vs. the original tables that have a blank prefix.
- Removed outliers of heat rates >100, and corrected a typo to have the top and bottom .5% of heat rates get replaced by the heat rate at the top and bottom .5 percentile, respectively. (typo was .8)
- Removed the generation projects that are in the list of retired generators from the EIA 860M monthly form (processed in the new function in scrape.py)
- Updated the max age of generation projects to reflect planned retirement years if available, with max age of the generation project to be Online Year (build_year in db) - Planned Retirement Year. For the generators that do not have planned retirement years: a default max_age is assigned to each generator based on their technology (that was the method in the previous version of this script).
- Added an option to have different generation_plant_scenario_id, hydro_simple_scenario_id, generation_plant_cost_scenario_id
- Included existing and proposed battery storage in the generator list. They were removed from the existing and planned generator list from EIA, and only included as candidate generators. 
- Set the storage_efficiency and store_to_release ratio values for all the existing battery storage, based on the values currently used for in the database for all the candidate battery storage generators:'storage_efficiency' = 0.75
'store_to_release_ratio' = 1
- added a function to compare the nameplate capacity by state and energy source between the old and new existing and planned generation scenarios
- Removed a time shift of 7 hours to the variable capacity factors tables
- Modified the variable capacity function to only add variable capacity factors for the generation projects belonging to the scenarios added in the script.

queries_to_create_db_backup_tables_for_testing.sql:
- Queries to create backup tables that are for testing the code. This is not meant run as is, but is a way to document the queries that create the backup tables.